### PR TITLE
feat: DNS-based cluster discovery from the location's CNAME

### DIFF
--- a/src/clappform/_discovery.py
+++ b/src/clappform/_discovery.py
@@ -1,0 +1,81 @@
+"""DNS-based cluster discovery.
+
+Every client environment (``location``) is a CNAME to its cluster's BigIP,
+and the BigIP hostname carries the same extension as that cluster's service
+hosts::
+
+    gelderland.clappform.com     CNAME  bigip.clappform.com           -> cluster ""
+    noord-brabant.clappform.com  CNAME  bigip-prod-lts.clappform.com  -> cluster "prod-lts"
+
+So one forward lookup of ``{location}.clappform.com`` yields the cluster
+extension: no reverse lookups, no registry, no extra dependencies. This
+module only derives the extension — which endpoints to build from it, and
+per-instance caching, belong to the client constructor. The ``location``
+metadata header sent on every call is unaffected.
+
+Discovery never guesses: any lookup failure or unexpected canonical name
+raises :class:`~clappform._errors.ConfigurationError` telling the caller to
+pass ``cluster=`` explicitly. Notably, resolvers that do not report
+canonical names (musl-based systems such as Alpine containers echo the
+queried name back) land in that error path instead of misresolving.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+from collections.abc import Callable
+
+from clappform._errors import ConfigurationError
+
+BASE_DOMAIN = "clappform.com"
+
+# Canonical name of a cluster's BigIP: bigip.clappform.com for the main
+# cluster, bigip-<extension>.clappform.com for every other one. A trailing
+# dot (FQDN form) is tolerated.
+_CANONICAL = re.compile(
+    r"^bigip(?:-(?P<ext>[a-z0-9-]+))?\.clappform\.com\.?$",
+    re.IGNORECASE,
+)
+
+# Returns the canonical hostname for the given hostname (CNAME chain target).
+Resolver = Callable[[str], str]
+
+
+def _default_resolver(host: str) -> str:
+    return socket.gethostbyname_ex(host)[0]
+
+
+def discover_cluster(location: str, *, resolver: Resolver | None = None) -> str:
+    """Derive the cluster extension for *location* from its CNAME target.
+
+    Returns the extension string: ``""`` for the main cluster,
+    ``"prod-lts"``-style values for every other cluster.
+
+    Raises :class:`ConfigurationError` when the lookup fails or the
+    canonical name does not match the BigIP convention — pass ``cluster=``
+    explicitly in that case.
+    """
+    if not location or not re.fullmatch(r"[a-z0-9-]+", location, re.IGNORECASE):
+        raise ConfigurationError(
+            f"cannot discover a cluster for location {location!r}: not a valid "
+            f"subdomain label; pass cluster= explicitly"
+        )
+    host = f"{location}.{BASE_DOMAIN}"
+    resolve = resolver or _default_resolver
+    try:
+        canonical = resolve(host)
+    except OSError as exc:  # socket.gaierror and friends
+        raise ConfigurationError(
+            f"cluster discovery failed: could not resolve {host!r} ({exc}); "
+            f"pass cluster= explicitly"
+        ) from exc
+
+    match = _CANONICAL.match(canonical)
+    if match is None:
+        raise ConfigurationError(
+            f"cluster discovery failed: {host!r} resolved to canonical name "
+            f"{canonical!r}, which does not match the expected "
+            f"bigip[-<cluster>].{BASE_DOMAIN} convention; pass cluster= explicitly"
+        )
+    return (match.group("ext") or "").lower()

--- a/src/clappform/_errors.py
+++ b/src/clappform/_errors.py
@@ -1,0 +1,18 @@
+"""Typed exception hierarchy for the Clappform client.
+
+Users should never need to import ``grpc`` to handle a failure: everything
+the client raises derives from :class:`ClappformError`. The hierarchy grows
+alongside the transport layer; only the configuration-time errors live here
+so far.
+"""
+
+from __future__ import annotations
+
+
+class ClappformError(Exception):
+    """Base class for every error raised by the Clappform client."""
+
+
+class ConfigurationError(ClappformError):
+    """Bad endpoints, credentials, or cluster settings — raised before any
+    RPC is attempted."""

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,75 @@
+"""Cluster discovery from the location's CNAME target.
+
+All tests inject a stub resolver — no live DNS is ever performed in CI.
+"""
+
+import socket
+
+import pytest
+
+from clappform._discovery import discover_cluster
+from clappform._errors import ClappformError, ConfigurationError
+
+
+def test_main_cluster_resolves_to_empty_extension() -> None:
+    resolver = lambda host: "bigip.clappform.com"  # noqa: E731
+    assert discover_cluster("gelderland", resolver=resolver) == ""
+
+
+def test_suffixed_cluster_extension_extracted() -> None:
+    resolver = lambda host: "bigip-prod-lts.clappform.com"  # noqa: E731
+    assert discover_cluster("noord-brabant", resolver=resolver) == "prod-lts"
+
+
+def test_queried_host_is_location_under_base_domain() -> None:
+    seen: list[str] = []
+
+    def resolver(host: str) -> str:
+        seen.append(host)
+        return "bigip-qa.clappform.com"
+
+    assert discover_cluster("acme", resolver=resolver) == "qa"
+    assert seen == ["acme.clappform.com"]
+
+
+def test_fqdn_trailing_dot_and_case_are_tolerated() -> None:
+    resolver = lambda host: "BigIP-QA-LTS.Clappform.com."  # noqa: E731
+    assert discover_cluster("acme", resolver=resolver) == "qa-lts"
+
+
+def test_nxdomain_raises_configuration_error_with_hint() -> None:
+    def resolver(host: str) -> str:
+        raise socket.gaierror(8, "nodename nor servname provided")
+
+    with pytest.raises(ConfigurationError, match="pass cluster= explicitly") as excinfo:
+        discover_cluster("does-not-exist", resolver=resolver)
+    assert "does-not-exist.clappform.com" in str(excinfo.value)
+
+
+def test_non_bigip_canonical_name_is_rejected() -> None:
+    resolver = lambda host: "some-other-lb.example.net"  # noqa: E731
+    with pytest.raises(ConfigurationError, match="does not match"):
+        discover_cluster("acme", resolver=resolver)
+
+
+def test_musl_style_echo_of_query_is_rejected_not_misread() -> None:
+    # musl resolvers report no canonical name and echo the queried host back;
+    # that must land in the fail-loud path, never be parsed as a cluster.
+    resolver = lambda host: host  # noqa: E731
+    with pytest.raises(ConfigurationError, match="pass cluster= explicitly"):
+        discover_cluster("acme", resolver=resolver)
+
+
+@pytest.mark.parametrize("location", ["", "acme.clappform.com", "bad_label", "a b"])
+def test_invalid_location_labels_fail_before_any_lookup(location: str) -> None:
+    def resolver(host: str) -> str:
+        raise AssertionError("resolver must not be called for invalid labels")
+
+    with pytest.raises(ConfigurationError, match="not a valid"):
+        discover_cluster(location, resolver=resolver)
+
+
+def test_errors_are_catchable_as_clappform_error() -> None:
+    resolver = lambda host: "wrong.example.com"  # noqa: E731
+    with pytest.raises(ClappformError):
+        discover_cluster("acme", resolver=resolver)


### PR DESCRIPTION
## Summary

- Adds `clappform._discovery.discover_cluster(location, *, resolver=...)`: resolves `{location}.clappform.com` and parses the canonical name against the `bigip[-<ext>].clappform.com` convention to yield the cluster extension (`""` for the main cluster).
- Fail-loud by design: lookup failures, foreign canonical names, and musl-style resolvers that echo the query back all raise `ConfigurationError` with a "pass cluster= explicitly" hint — discovery never guesses. Location labels are validated before any lookup.
- Starts the typed error hierarchy (`ClappformError` base, `ConfigurationError`) that the transport work extends.
- The resolver is injectable, so the constructor wiring and all tests run without live DNS.

## Related issues

- Implements #53 — v6: DNS-based cluster discovery — derive cluster from the location's CNAME

## Tests

- tests/test_discovery.py — main/suffixed clusters, FQDN + case tolerance, queried-host shape, NXDOMAIN, non-bigip canonical name, musl-style echo, invalid labels rejected pre-lookup, ClappformError catchability (stubbed resolvers throughout, no live DNS)
- `ruff check .`, `mypy src/clappform tools` (207 files), `pytest` (32 tests) passing locally

## Notes

- Partial delivery on purpose: #53's remaining criteria (optional `cluster=` on the constructor, per-instance caching, `with_location()` re-discovery, error-report context, quickstart docs) sit in the constructor/transport/docs work (#36, #39, #48) — this PR ships the discovery engine they wire in, so #53 stays open.
- `socket.gethostbyname_ex` carries no timeout parameter; discovery inherits the OS resolver timeout. Worth revisiting in the transport wiring if construction-time latency ever matters.
- The CNAME convention is now an API contract for this feature — the infra runbook line called out in #53 still applies.