### PR TITLE
feat: client core — transport, auth, errors, and the Clappform class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "mypy>=1.10",
     "grpcio-tools>=1.60,<2",
     "types-protobuf",
+    "types-grpcio",
 ]
 
 [project.urls]

--- a/src/clappform/__init__.py
+++ b/src/clappform/__init__.py
@@ -1,7 +1,39 @@
 """Python client for the Clappform gRPC APIs."""
 
+from clappform import _runtime  # noqa: F401  (must precede _client: services import it)
+from clappform._auth import ApiKey, Credentials
+from clappform._client import Clappform
+from clappform._errors import (
+    AuthenticationError,
+    ClappformError,
+    ConfigurationError,
+    ConflictError,
+    InvalidRequestError,
+    NotFoundError,
+    NotSupportedError,
+    PermissionDeniedError,
+    TransientError,
+)
 from clappform._proto_version import __proto_version__
+from clappform._transport import DEFAULT_RETRIES, RetryPolicy
 
 __version__ = "6.0.0a0"
 
-__all__ = ["__proto_version__", "__version__"]
+__all__ = [
+    "DEFAULT_RETRIES",
+    "ApiKey",
+    "AuthenticationError",
+    "Clappform",
+    "ClappformError",
+    "ConfigurationError",
+    "ConflictError",
+    "Credentials",
+    "InvalidRequestError",
+    "NotFoundError",
+    "NotSupportedError",
+    "PermissionDeniedError",
+    "RetryPolicy",
+    "TransientError",
+    "__proto_version__",
+    "__version__",
+]

--- a/src/clappform/_auth.py
+++ b/src/clappform/_auth.py
@@ -1,0 +1,37 @@
+"""Credentials for the Clappform APIs.
+
+v1 ships API keys only. The :class:`Credentials` protocol is the seam other
+flows (token exchange, SSO) plug into later: a credential's only job is to
+contribute metadata to each call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from clappform._errors import ConfigurationError
+
+
+@runtime_checkable
+class Credentials(Protocol):
+    """Anything that can attach auth metadata to a call."""
+
+    def metadata_for_call(self) -> tuple[tuple[str, str], ...]: ...
+
+
+@dataclass(frozen=True)
+class ApiKey:
+    """API-key credential, sent as ``x-api-key`` metadata on every call."""
+
+    key: str
+
+    def __post_init__(self) -> None:
+        if not self.key or not self.key.strip():
+            raise ConfigurationError("api_key must be a non-empty string")
+
+    def metadata_for_call(self) -> tuple[tuple[str, str], ...]:
+        return (("x-api-key", self.key),)
+
+    def __repr__(self) -> str:  # never leak the key into logs or errors
+        return "ApiKey(***)"

--- a/src/clappform/_client.py
+++ b/src/clappform/_client.py
@@ -1,0 +1,178 @@
+"""The Clappform client: one instance = one (cluster, location, credentials)
+binding.
+
+Nothing is global — two instances pointed at two clusters coexist in one
+process, and :meth:`Clappform.with_location` gives a cheap same-cluster
+clone for another tenant, sharing connections and configuration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clappform import _discovery, _runtime
+from clappform._auth import ApiKey, Credentials
+from clappform._errors import ConfigurationError
+from clappform._transport import (
+    DEFAULT_RETRIES,
+    GrpcTransport,
+    RetryPolicy,
+    resolve_endpoints,
+)
+from clappform.services import API_FAMILIES
+
+
+class _BoundCaller:
+    """Caller that injects an instance's default tenant location.
+
+    Per-call ``location=`` overrides still win; everything else is passed
+    straight through to the underlying transport (or test double).
+    """
+
+    __slots__ = ("_inner", "_location")
+
+    def __init__(self, inner: _runtime.Caller, location: str) -> None:
+        self._inner = inner
+        self._location = location
+
+    def invoke(self, kind, method, request, request_cls, response_cls, **options):
+        if options.get("location") is None:
+            options["location"] = self._location
+        return self._inner.invoke(
+            kind, method, request, request_cls, response_cls, **options
+        )
+
+
+class Clappform:
+    """Client for every Clappform API on one cluster, bound to one tenant.
+
+    ``cluster`` is the host extension (``"qa"``, ``"qa-lts"``, ``"prod"`` or
+    ``""`` for the main cluster). When omitted, it is discovered from the
+    DNS CNAME of ``{location}.clappform.com`` — pass it explicitly in
+    air-gapped or split-DNS environments.
+
+    All configuration is explicit constructor input: the library reads no
+    config files and no environment variables.
+    """
+
+    def __init__(
+        self,
+        location: str,
+        cluster: str | None = None,
+        *,
+        api_key: str | None = None,
+        credentials: Credentials | None = None,
+        endpoints: dict[str, str] | None = None,
+        insecure: bool = False,
+        timeout: float | None = 60.0,
+        retries: RetryPolicy | None = DEFAULT_RETRIES,
+        channel_options: list[tuple[str, Any]] | None = None,
+        transport: _runtime.Caller | None = None,
+    ) -> None:
+        if not location:
+            raise ConfigurationError("location is required")
+        if (api_key is None) == (credentials is None):
+            raise ConfigurationError(
+                "pass exactly one of api_key= or credentials="
+            )
+        self._credentials = credentials if credentials is not None else ApiKey(api_key)  # type: ignore[arg-type]
+        self.location = location
+        self.cluster_discovered = cluster is None
+        self.cluster = (
+            _discovery.discover_cluster(location) if cluster is None else cluster
+        )
+
+        self._init_options: dict[str, Any] = {
+            "endpoints": endpoints,
+            "insecure": insecure,
+            "timeout": timeout,
+            "retries": retries,
+            "channel_options": channel_options,
+        }
+        if transport is not None:
+            self._transport: _runtime.Caller = transport
+            self._owns_transport = False
+        else:
+            self._transport = GrpcTransport(
+                endpoints=resolve_endpoints(self.cluster, endpoints),
+                credentials=self._credentials,
+                cluster=self.cluster,
+                insecure=insecure,
+                default_timeout=timeout,
+                retries=retries,
+                channel_options=channel_options,
+            )
+            self._owns_transport = True
+
+        self._bind_services()
+
+    def _bind_services(self) -> None:
+        caller = _BoundCaller(self._transport, self.location)
+        for family, api_cls in API_FAMILIES.items():
+            setattr(self, family, api_cls(caller))
+
+    def with_location(self, location: str) -> Clappform:
+        """A clone bound to another tenant, sharing connections when possible.
+
+        With an explicitly configured cluster (or a custom transport) the
+        clone inherits it and shares the transport — only the tenant
+        metadata differs, and no DNS is performed. When this instance's
+        cluster was *discovered*, a different location is re-discovered:
+        if it lands on the same cluster the transport is still shared,
+        otherwise the clone gets its own transport for its own cluster.
+        """
+        if not location:
+            raise ConfigurationError("location is required")
+        if location == self.location:
+            return self
+
+        if self.cluster_discovered and self._owns_transport:
+            new_cluster = _discovery.discover_cluster(location)
+            if new_cluster != self.cluster:
+                clone = Clappform(
+                    location,
+                    new_cluster,
+                    credentials=self._credentials,
+                    transport=None,
+                    **self._init_options,
+                )
+                clone.cluster_discovered = True
+                return clone
+
+        clone = object.__new__(Clappform)
+        clone.__dict__.update(self.__dict__)
+        clone.location = location
+        clone._owns_transport = False  # the parent owns the channels
+        clone._bind_services()
+        return clone
+
+    def channel_for(self, family: str):
+        """The live gRPC channel for an API family (transport-owned only)."""
+        if not isinstance(self._transport, GrpcTransport):
+            raise ConfigurationError(
+                "channel_for() is unavailable with a custom transport"
+            )
+        return self._transport.channel_for(family)
+
+    def close(self) -> None:
+        if self._owns_transport:
+            close = getattr(self._transport, "close", None)
+            if close is not None:
+                close()
+
+    def __enter__(self) -> Clappform:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        from clappform import __proto_version__, __version__
+
+        cluster = self.cluster or "main"
+        discovered = " (discovered)" if self.cluster_discovered else ""
+        return (
+            f"Clappform(cluster={cluster!r}{discovered}, "
+            f"location={self.location!r}, auth={type(self._credentials).__name__}, "
+            f"version={__version__}, protos={__proto_version__})"
+        )

--- a/src/clappform/_errors.py
+++ b/src/clappform/_errors.py
@@ -1,18 +1,141 @@
 """Typed exception hierarchy for the Clappform client.
 
-Users should never need to import ``grpc`` to handle a failure: everything
-the client raises derives from :class:`ClappformError`. The hierarchy grows
-alongside the transport layer; only the configuration-time errors live here
-so far.
+Users never need to import ``grpc`` to handle a failure: every error the
+client raises derives from :class:`ClappformError`, and each one carries the
+call context (API family, method, cluster, location) so "which tenant on
+which cluster failed" is always in the message.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import grpc
 
 
 class ClappformError(Exception):
     """Base class for every error raised by the Clappform client."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: str | None = None,
+        method: str | None = None,
+        cluster: str | None = None,
+        location: str | None = None,
+        details: str | None = None,
+    ) -> None:
+        self.status = status
+        self.method = method
+        self.cluster = cluster
+        self.location = location
+        self.details = details
+        context = []
+        if method:
+            context.append(f"method={method}")
+        if cluster is not None:
+            context.append(f"cluster={(cluster or 'main')!r}")
+        if location:
+            context.append(f"location={location!r}")
+        if status:
+            context.append(f"status={status}")
+        suffix = f" ({', '.join(context)})" if context else ""
+        super().__init__(f"{message}{suffix}")
+
 
 class ConfigurationError(ClappformError):
     """Bad endpoints, credentials, or cluster settings — raised before any
-    RPC is attempted."""
+    RPC is attempted, or when the server reports missing call configuration."""
+
+
+class AuthenticationError(ClappformError):
+    """The server rejected the call's credentials (UNAUTHENTICATED)."""
+
+
+class PermissionDeniedError(ClappformError):
+    """Authenticated, but not allowed to perform this call (PERMISSION_DENIED)."""
+
+
+class NotFoundError(ClappformError):
+    """The referenced entity does not exist (NOT_FOUND)."""
+
+
+class InvalidRequestError(ClappformError):
+    """The request was malformed or violated a precondition
+    (INVALID_ARGUMENT / FAILED_PRECONDITION / OUT_OF_RANGE)."""
+
+
+class ConflictError(ClappformError):
+    """The call conflicts with existing state (ALREADY_EXISTS / ABORTED)."""
+
+
+class NotSupportedError(ClappformError):
+    """The server does not implement this RPC (UNIMPLEMENTED). Clusters are
+    updated at different times, so a newer client may call an RPC an older
+    cluster does not serve yet."""
+
+
+class TransientError(ClappformError):
+    """The call failed in a retryable way and retries were exhausted
+    (UNAVAILABLE / DEADLINE_EXCEEDED)."""
+
+
+# The authoriser's location interceptor aborts calls that carry no usable
+# tenant header with this message; surface it as a configuration problem.
+_LOCATION_HEADER_DETAIL = "invalid/missing header: 'location'"
+
+_STATUS_MAP: dict[str, type[ClappformError]] = {
+    "UNAUTHENTICATED": AuthenticationError,
+    "PERMISSION_DENIED": PermissionDeniedError,
+    "NOT_FOUND": NotFoundError,
+    "INVALID_ARGUMENT": InvalidRequestError,
+    "FAILED_PRECONDITION": InvalidRequestError,
+    "OUT_OF_RANGE": InvalidRequestError,
+    "ALREADY_EXISTS": ConflictError,
+    "ABORTED": ConflictError,
+    "UNIMPLEMENTED": NotSupportedError,
+    "UNAVAILABLE": TransientError,
+    "DEADLINE_EXCEEDED": TransientError,
+}
+
+
+def translate_rpc_error(
+    error: grpc.RpcError,
+    *,
+    method: str | None = None,
+    cluster: str | None = None,
+    location: str | None = None,
+) -> ClappformError:
+    """Map a grpc.RpcError onto the typed hierarchy, preserving call context."""
+    status = getattr(error, "code", lambda: None)()
+    status_name = status.name if status is not None else "UNKNOWN"
+    details = getattr(error, "details", lambda: "")() or ""
+
+    if _LOCATION_HEADER_DETAIL in details:
+        return ConfigurationError(
+            f"{details} — the server received no usable tenant header; "
+            f"check the location= argument",
+            status=status_name,
+            method=method,
+            cluster=cluster,
+            location=location,
+            details=details,
+        )
+
+    exc_cls = _STATUS_MAP.get(status_name, ClappformError)
+    message = details or f"RPC failed with status {status_name}"
+    if exc_cls is NotSupportedError:
+        message = (
+            f"{message} — this cluster may not serve this RPC yet; "
+            f"cluster rollouts are staggered"
+        )
+    return exc_cls(
+        message,
+        status=status_name,
+        method=method,
+        cluster=cluster,
+        location=location,
+        details=details,
+    )

--- a/src/clappform/_transport.py
+++ b/src/clappform/_transport.py
@@ -1,0 +1,222 @@
+"""gRPC transport: endpoint resolution, channels, retries, and the Caller.
+
+The generated service layer talks to a :class:`~clappform._runtime.Caller`;
+:class:`GrpcTransport` is the production implementation. It owns one lazily
+created channel per endpoint, composes per-call metadata (credentials +
+tenant location + caller extras), applies the default deadline, and
+translates every ``grpc.RpcError`` into the typed hierarchy — including
+errors raised mid-iteration on streaming responses.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import grpc
+
+from clappform._auth import Credentials
+from clappform._errors import ConfigurationError, translate_rpc_error
+from clappform._runtime import CallKind
+
+BASE_DOMAIN = "clappform.com"
+DEFAULT_PORT = 443
+
+# Host prefix per API family, forming {prefix}{-extension}.clappform.com.
+# The authoriser serves under "auth", matching its family alias.
+HOST_PREFIXES = {
+    "data": "data",
+    "client": "client",
+    "auth": "auth",
+    "notifier": "notifier",
+}
+
+# Package segment -> family alias, mirroring the generated service layer.
+_PACKAGE_FAMILIES = {"authoriser": "auth"}
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Retry configuration applied through gRPC's built-in retry support."""
+
+    max_attempts: int = 4
+    initial_backoff: str = "0.2s"
+    max_backoff: str = "2s"
+    backoff_multiplier: float = 2.0
+    retryable_status_codes: tuple[str, ...] = ("UNAVAILABLE",)
+
+    def service_config(self) -> str:
+        import json
+
+        return json.dumps(
+            {
+                "methodConfig": [
+                    {
+                        "name": [{}],
+                        "retryPolicy": {
+                            "maxAttempts": self.max_attempts,
+                            "initialBackoff": self.initial_backoff,
+                            "maxBackoff": self.max_backoff,
+                            "backoffMultiplier": self.backoff_multiplier,
+                            "retryableStatusCodes": list(self.retryable_status_codes),
+                        },
+                    }
+                ]
+            }
+        )
+
+
+DEFAULT_RETRIES = RetryPolicy()
+
+_BASE_CHANNEL_OPTIONS: list[tuple[str, Any]] = [
+    ("grpc.keepalive_time_ms", 30_000),
+    ("grpc.keepalive_timeout_ms", 10_000),
+    ("grpc.keepalive_permit_without_calls", 1),
+    ("grpc.max_send_message_length", 64 * 1024 * 1024),
+    ("grpc.max_receive_message_length", 64 * 1024 * 1024),
+]
+
+
+def resolve_endpoints(
+    cluster: str,
+    overrides: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the per-family endpoint map for a cluster extension.
+
+    ``cluster`` is the host extension: ``""`` (or ``"prod"``) for the main
+    cluster, ``"qa"``-style values otherwise. Explicit ``overrides`` win per
+    family and may carry their own port.
+    """
+    extension = cluster.strip().lstrip("-").lower()
+    if extension == "prod":
+        extension = ""
+    suffix = f"-{extension}" if extension else ""
+    endpoints = {
+        family: f"{prefix}{suffix}.{BASE_DOMAIN}:{DEFAULT_PORT}"
+        for family, prefix in HOST_PREFIXES.items()
+    }
+    for family, address in (overrides or {}).items():
+        if family not in endpoints:
+            raise ConfigurationError(
+                f"unknown API family {family!r} in endpoints=; "
+                f"expected one of {sorted(endpoints)}"
+            )
+        endpoints[family] = address
+    return endpoints
+
+
+def family_of_method(method: str) -> str:
+    """'/clappform.data.v1.insert.InsertManagement/InsertMany' -> 'data'."""
+    package = method.lstrip("/").split("/", 1)[0]
+    parts = package.split(".")
+    if len(parts) < 2 or parts[0] != "clappform":
+        raise ConfigurationError(f"cannot derive API family from method {method!r}")
+    segment = parts[1]
+    return _PACKAGE_FAMILIES.get(segment, segment)
+
+
+@dataclass
+class GrpcTransport:
+    """Production Caller: channels, metadata, deadlines, error translation."""
+
+    endpoints: dict[str, str]
+    credentials: Credentials
+    cluster: str
+    insecure: bool = False
+    default_timeout: float | None = 60.0
+    retries: RetryPolicy | None = DEFAULT_RETRIES
+    channel_options: list[tuple[str, Any]] | None = None
+
+    _channels: dict[str, grpc.Channel] = field(default_factory=dict, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    def _options(self) -> list[tuple[str, Any]]:
+        options = list(_BASE_CHANNEL_OPTIONS)
+        if self.retries is not None:
+            options.append(("grpc.enable_retries", 1))
+            options.append(("grpc.service_config", self.retries.service_config()))
+        if self.channel_options:
+            options.extend(self.channel_options)
+        return options
+
+    def channel_for(self, family: str) -> grpc.Channel:
+        try:
+            address = self.endpoints[family]
+        except KeyError:
+            raise ConfigurationError(
+                f"no endpoint configured for API family {family!r}"
+            ) from None
+        with self._lock:
+            if self._closed:
+                raise ConfigurationError("client is closed")
+            channel = self._channels.get(address)
+            if channel is None:
+                if self.insecure:
+                    channel = grpc.insecure_channel(address, options=self._options())
+                else:
+                    channel = grpc.secure_channel(
+                        address, grpc.ssl_channel_credentials(), options=self._options()
+                    )
+                self._channels[address] = channel
+            return channel
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            channels, self._channels = list(self._channels.values()), {}
+        for channel in channels:
+            channel.close()
+
+    def _metadata(
+        self,
+        location: str | None,
+        extra: tuple[tuple[str, str], ...] | None,
+    ) -> tuple[tuple[str, str], ...]:
+        metadata = list(self.credentials.metadata_for_call())
+        if location:
+            metadata.append(("location", location))
+        if extra:
+            metadata.extend(extra)
+        return tuple(metadata)
+
+    def invoke(
+        self,
+        kind: CallKind,
+        method: str,
+        request: Any,
+        request_cls: Any,  # protobuf message class (SerializeToString/FromString)
+        response_cls: Any,
+        *,
+        timeout: float | None = None,
+        metadata: tuple[tuple[str, str], ...] | None = None,
+        location: str | None = None,
+    ) -> Any:
+        family = family_of_method(method)
+        channel = self.channel_for(family)
+        multicallable = getattr(channel, kind)(
+            method,
+            request_serializer=request_cls.SerializeToString,
+            response_deserializer=response_cls.FromString,
+        )
+        call_kwargs = {
+            "timeout": timeout if timeout is not None else self.default_timeout,
+            "metadata": self._metadata(location, metadata),
+        }
+        context = {"method": method, "cluster": self.cluster, "location": location}
+        try:
+            result = multicallable(request, **call_kwargs)
+        except grpc.RpcError as exc:
+            raise translate_rpc_error(exc, **context) from exc
+        if kind.endswith("_stream"):
+            return self._translating_iterator(result, context)
+        return result
+
+    @staticmethod
+    def _translating_iterator(stream: Any, context: dict[str, Any]) -> Iterator[Any]:
+        try:
+            yield from stream
+        except grpc.RpcError as exc:
+            raise translate_rpc_error(exc, **context) from exc

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,24 @@
+"""API-key credential behaviour."""
+
+import pytest
+
+from clappform._auth import ApiKey, Credentials
+from clappform._errors import ConfigurationError
+
+
+def test_api_key_emits_x_api_key_metadata() -> None:
+    assert ApiKey("secret").metadata_for_call() == (("x-api-key", "secret"),)
+
+
+def test_api_key_satisfies_credentials_protocol() -> None:
+    assert isinstance(ApiKey("secret"), Credentials)
+
+
+@pytest.mark.parametrize("bad", ["", "   "])
+def test_blank_api_key_rejected(bad: str) -> None:
+    with pytest.raises(ConfigurationError, match="non-empty"):
+        ApiKey(bad)
+
+
+def test_repr_never_leaks_the_key() -> None:
+    assert "secret" not in repr(ApiKey("secret"))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,172 @@
+"""Clappform client construction, discovery wiring, tenancy, and lifecycle."""
+
+import pytest
+
+from clappform import ApiKey, Clappform, ConfigurationError
+from clappform import _client as client_mod
+from clappform._transport import resolve_endpoints
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def invoke(self, kind, method, request, request_cls, response_cls, **options):
+        self.calls.append((method, options.get("location")))
+        return response_cls()
+
+
+def make_client(cluster: str = "qa", **kwargs) -> tuple[Clappform, FakeTransport]:
+    transport = FakeTransport()
+    defaults: dict = {"api_key": "k", "transport": transport}
+    defaults.update(kwargs)
+    return Clappform("acme", cluster, **defaults), transport
+
+
+# --- construction validation -------------------------------------------------
+
+def test_requires_location() -> None:
+    with pytest.raises(ConfigurationError, match="location"):
+        Clappform("", "qa", api_key="k")
+
+
+def test_requires_exactly_one_credential_source() -> None:
+    with pytest.raises(ConfigurationError, match="exactly one"):
+        Clappform("acme", "qa")
+    with pytest.raises(ConfigurationError, match="exactly one"):
+        Clappform("acme", "qa", api_key="k", credentials=ApiKey("x"))
+
+
+def test_sub_clients_are_wired() -> None:
+    cf, _ = make_client()
+    for family in ("data", "client", "auth", "notifier"):
+        assert hasattr(cf, family)
+
+
+def test_default_location_injected_and_per_call_override_wins() -> None:
+    cf, transport = make_client()
+    cf.data.insert.insert_single(collection="orders")
+    cf.data.insert.insert_single(collection="orders", location="umbrella")
+    assert [loc for _m, loc in transport.calls] == ["acme", "umbrella"]
+
+
+# --- endpoint resolution ------------------------------------------------------
+
+def test_endpoint_resolution_variants() -> None:
+    assert resolve_endpoints("qa")["data"] == "data-qa.clappform.com:443"
+    assert resolve_endpoints("")["data"] == "data.clappform.com:443"
+    assert resolve_endpoints("prod")["auth"] == "auth.clappform.com:443"
+    assert resolve_endpoints("QA-LTS")["client"] == "client-qa-lts.clappform.com:443"
+
+
+def test_endpoint_override_wins_and_unknown_family_rejected() -> None:
+    resolved = resolve_endpoints("qa", {"data": "10.0.0.5:50051"})
+    assert resolved["data"] == "10.0.0.5:50051"
+    assert resolved["auth"] == "auth-qa.clappform.com:443"
+    with pytest.raises(ConfigurationError, match="unknown API family"):
+        resolve_endpoints("qa", {"nbflow": "x:1"})
+
+
+# --- cluster discovery wiring -------------------------------------------------
+
+def test_explicit_cluster_never_discovers(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(location: str) -> str:
+        raise AssertionError("discovery must not run for explicit cluster")
+
+    monkeypatch.setattr(client_mod._discovery, "discover_cluster", boom)
+    cf, _ = make_client(cluster="qa")
+    assert cf.cluster == "qa"
+    assert cf.cluster_discovered is False
+
+
+def test_omitted_cluster_is_discovered(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        client_mod._discovery, "discover_cluster", lambda loc: "prod-lts"
+    )
+    cf = Clappform("noord-brabant", api_key="k", transport=FakeTransport())
+    assert cf.cluster == "prod-lts"
+    assert cf.cluster_discovered is True
+    assert "(discovered)" in repr(cf)
+
+
+def test_discovery_failure_propagates_with_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(location: str) -> str:
+        raise ConfigurationError("cluster discovery failed; pass cluster= explicitly")
+
+    monkeypatch.setattr(client_mod._discovery, "discover_cluster", fail)
+    with pytest.raises(ConfigurationError, match="pass cluster= explicitly"):
+        Clappform("acme", api_key="k", transport=FakeTransport())
+
+
+# --- with_location ------------------------------------------------------------
+
+def test_with_location_shares_transport_for_explicit_cluster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        client_mod._discovery,
+        "discover_cluster",
+        lambda loc: pytest.fail("no discovery for explicit cluster"),
+    )
+    cf, transport = make_client(cluster="qa")
+    clone = cf.with_location("umbrella")
+    clone.data.insert.insert_single(collection="orders")
+    assert transport.calls == [
+        ("/clappform.data.v1.insert.InsertManagement/InsertSingle", "umbrella")
+    ]
+    assert clone.cluster == "qa"
+
+
+def test_with_location_same_location_returns_self() -> None:
+    cf, _ = make_client()
+    assert cf.with_location("acme") is cf
+
+
+def test_with_location_rediscovers_only_for_discovered_cluster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lookups: list[str] = []
+
+    def fake_discover(location: str) -> str:
+        lookups.append(location)
+        return {"acme": "qa", "umbrella": "qa", "gelderland": ""}[location]
+
+    monkeypatch.setattr(client_mod._discovery, "discover_cluster", fake_discover)
+    cf = Clappform("acme", api_key="k", endpoints={"data": "127.0.0.1:1"}, insecure=True)
+    try:
+        same = cf.with_location("umbrella")  # same cluster -> shared transport
+        assert same.cluster == "qa"
+        assert same._transport is cf._transport
+        other = cf.with_location("gelderland")  # different cluster -> own transport
+        assert other.cluster == ""
+        assert other.cluster_discovered is True
+        assert other._transport is not cf._transport
+        assert lookups == ["acme", "umbrella", "gelderland"]
+        other.close()
+    finally:
+        cf.close()
+
+
+# --- lifecycle ----------------------------------------------------------------
+
+def test_context_manager_closes_owned_transport() -> None:
+    closed: list[bool] = []
+
+    class ClosableTransport(FakeTransport):
+        def close(self) -> None:
+            closed.append(True)
+
+    transport = ClosableTransport()
+    with Clappform("acme", "qa", api_key="k", transport=transport):
+        pass
+    # custom transports are caller-owned: the client must NOT close them
+    assert closed == []
+
+    cf = Clappform("acme", "qa", api_key="k", endpoints={"data": "127.0.0.1:1"}, insecure=True)
+    cf.close()  # owned transport: close() must not raise, channels torn down
+
+
+def test_channel_for_rejected_on_custom_transport() -> None:
+    cf, _ = make_client()
+    with pytest.raises(ConfigurationError, match="custom transport"):
+        cf.channel_for("data")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,91 @@
+"""gRPC status translation into the typed error hierarchy."""
+
+import grpc
+import pytest
+
+from clappform._errors import (
+    AuthenticationError,
+    ClappformError,
+    ConfigurationError,
+    ConflictError,
+    InvalidRequestError,
+    NotFoundError,
+    NotSupportedError,
+    PermissionDeniedError,
+    TransientError,
+    translate_rpc_error,
+)
+
+
+class FakeRpcError(grpc.RpcError):
+    def __init__(self, code: grpc.StatusCode, details: str = "") -> None:
+        self._code = code
+        self._details = details
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str:
+        return self._details
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (grpc.StatusCode.UNAUTHENTICATED, AuthenticationError),
+        (grpc.StatusCode.PERMISSION_DENIED, PermissionDeniedError),
+        (grpc.StatusCode.NOT_FOUND, NotFoundError),
+        (grpc.StatusCode.INVALID_ARGUMENT, InvalidRequestError),
+        (grpc.StatusCode.FAILED_PRECONDITION, InvalidRequestError),
+        (grpc.StatusCode.ALREADY_EXISTS, ConflictError),
+        (grpc.StatusCode.ABORTED, ConflictError),
+        (grpc.StatusCode.UNIMPLEMENTED, NotSupportedError),
+        (grpc.StatusCode.UNAVAILABLE, TransientError),
+        (grpc.StatusCode.DEADLINE_EXCEEDED, TransientError),
+        (grpc.StatusCode.INTERNAL, ClappformError),
+    ],
+)
+def test_status_maps_to_typed_error(status, expected) -> None:
+    error = translate_rpc_error(FakeRpcError(status, "boom"))
+    assert type(error) is expected
+    assert error.status == status.name
+
+
+def test_context_appears_in_message() -> None:
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.NOT_FOUND, "no such collection"),
+        method="/clappform.data.v1.x.Y/Get",
+        cluster="qa-lts",
+        location="acme",
+    )
+    text = str(error)
+    assert "no such collection" in text
+    assert "cluster='qa-lts'" in text
+    assert "location='acme'" in text
+    assert "status=NOT_FOUND" in text
+
+
+def test_empty_cluster_reads_as_main() -> None:
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.NOT_FOUND, "x"), cluster="", location="acme"
+    )
+    assert "cluster='main'" in str(error)
+
+
+def test_missing_location_header_becomes_configuration_error() -> None:
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.ABORTED, "invalid/missing header: 'location'"),
+        location=None,
+    )
+    assert isinstance(error, ConfigurationError)
+    assert "location=" in str(error)
+
+
+def test_unimplemented_carries_staggered_rollout_hint() -> None:
+    error = translate_rpc_error(FakeRpcError(grpc.StatusCode.UNIMPLEMENTED, "nope"))
+    assert "may not serve this RPC yet" in str(error)
+
+
+def test_everything_catchable_via_base() -> None:
+    error = translate_rpc_error(FakeRpcError(grpc.StatusCode.UNKNOWN, ""))
+    assert isinstance(error, ClappformError)

--- a/tests/test_transport_grpc.py
+++ b/tests/test_transport_grpc.py
@@ -1,0 +1,144 @@
+"""End-to-end transport behaviour against a real in-process gRPC server.
+
+Covers the full stack: generated service layer -> bound caller -> transport
+-> wire -> servicer, including metadata composition, deadlines, streaming,
+and error translation. Only the data endpoint is overridden; nothing here
+touches the network beyond 127.0.0.1.
+"""
+
+import time
+from concurrent import futures
+
+import grpc
+import pytest
+
+from clappform import (
+    Clappform,
+    ConfigurationError,
+    NotFoundError,
+    NotSupportedError,
+    TransientError,
+)
+from clappform._transport import RetryPolicy
+from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2, aggregate_pb2_grpc
+from clappform.gen.clappform.data.v1.insert import insert_pb2, insert_pb2_grpc
+
+
+class InsertServicer(insert_pb2_grpc.InsertManagementServicer):
+    def __init__(self) -> None:
+        self.seen_metadata: dict[str, str] = {}
+
+    def InsertSingle(self, request, context):
+        self.seen_metadata = dict(context.invocation_metadata())
+        if request.collection == "missing":
+            context.abort(grpc.StatusCode.NOT_FOUND, "collection 'missing' not found")
+        if request.collection == "no-tenant":
+            context.abort(grpc.StatusCode.ABORTED, "invalid/missing header: 'location'")
+        if request.collection == "slow":
+            time.sleep(0.5)
+        return insert_pb2.InsertResponse(processed_count=1, oids=["oid-1"])
+
+
+class AggregateServicer(aggregate_pb2_grpc.AggregateManagementServicer):
+    def AggregateStream(self, request, context):
+        for chunk in (b"[1]", b"[2]", b"[3]"):
+            yield aggregate_pb2.AggregateResponse(data=chunk, total=3)
+
+
+@pytest.fixture(scope="module")
+def server():
+    insert_servicer = InsertServicer()
+    grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    insert_pb2_grpc.add_InsertManagementServicer_to_server(insert_servicer, grpc_server)
+    aggregate_pb2_grpc.add_AggregateManagementServicer_to_server(
+        AggregateServicer(), grpc_server
+    )
+    port = grpc_server.add_insecure_port("127.0.0.1:0")
+    grpc_server.start()
+    yield f"127.0.0.1:{port}", insert_servicer
+    grpc_server.stop(grace=None)
+
+
+@pytest.fixture
+def cf(server):
+    address, _servicer = server
+    client = Clappform(
+        "acme",
+        "qa",
+        api_key="test-key",
+        endpoints={"data": address},
+        insecure=True,
+        timeout=5.0,
+        retries=RetryPolicy(max_attempts=2),
+    )
+    yield client
+    client.close()
+
+
+def test_unary_call_roundtrip_with_metadata(cf, server) -> None:
+    _address, servicer = server
+    response = cf.data.insert.insert_single(collection="orders", data=b"[]")
+    assert response.processed_count == 1
+    assert servicer.seen_metadata["x-api-key"] == "test-key"
+    assert servicer.seen_metadata["location"] == "acme"
+
+
+def test_per_call_location_overrides_metadata(cf, server) -> None:
+    _address, servicer = server
+    cf.data.insert.insert_single(collection="orders", location="umbrella")
+    assert servicer.seen_metadata["location"] == "umbrella"
+
+
+def test_server_streaming_iterates_chunks(cf) -> None:
+    chunks = list(cf.data.aggregate.aggregate_stream(collection="orders"))
+    assert [c.data for c in chunks] == [b"[1]", b"[2]", b"[3]"]
+    assert chunks[0].total == 3
+
+
+def test_not_found_translates(cf) -> None:
+    with pytest.raises(NotFoundError, match="collection 'missing' not found") as excinfo:
+        cf.data.insert.insert_single(collection="missing")
+    assert "cluster='qa'" in str(excinfo.value)
+    assert "location='acme'" in str(excinfo.value)
+
+
+def test_missing_location_server_detail_becomes_configuration_error(cf) -> None:
+    with pytest.raises(ConfigurationError, match="location="):
+        cf.data.insert.insert_single(collection="no-tenant")
+
+
+def test_unregistered_service_maps_to_not_supported(cf) -> None:
+    with pytest.raises(NotSupportedError, match="may not serve this RPC yet"):
+        cf.data.delete.clear(collection="orders")
+
+
+def test_deadline_exceeded_translates_to_transient(cf) -> None:
+    with pytest.raises(TransientError) as excinfo:
+        cf.data.insert.insert_single(collection="slow", timeout=0.05)
+    assert excinfo.value.status == "DEADLINE_EXCEEDED"
+
+
+def test_unreachable_endpoint_translates_to_transient() -> None:
+    cf = Clappform(
+        "acme",
+        "qa",
+        api_key="k",
+        endpoints={"data": "127.0.0.1:1"},
+        insecure=True,
+        timeout=1.0,
+        retries=None,
+    )
+    try:
+        with pytest.raises(TransientError):
+            cf.data.insert.insert_single(collection="orders")
+    finally:
+        cf.close()
+
+
+def test_retry_policy_service_config_shape() -> None:
+    import json
+
+    config = json.loads(RetryPolicy(max_attempts=3).service_config())
+    policy = config["methodConfig"][0]["retryPolicy"]
+    assert policy["maxAttempts"] == 3
+    assert policy["retryableStatusCodes"] == ["UNAVAILABLE"]


### PR DESCRIPTION
## Summary

- `GrpcTransport` implements the `Caller` seam the generated layer targets: lazy channel per endpoint, TLS by default (`insecure=True` escape hatch), keepalive + 64MB limits, UNAVAILABLE retries via grpc service config, and error translation at the invoke boundary — including mid-stream errors on streaming responses. Endpoints resolve per API family from the `{prefix}{-extension}.clappform.com` convention with per-family overrides.
- Typed error hierarchy: every failure is a `ClappformError` subclass carrying method/cluster/location/status context. `UNIMPLEMENTED` → `NotSupportedError` with a staggered-rollout hint; the server's missing-location detail → `ConfigurationError` pointing at `location=`.
- `ApiKey` credential (x-api-key metadata, leak-proof repr) behind the minimal `Credentials` protocol for future flows.
- `Clappform(location, cluster=None, *, api_key=...)`: optional cluster with CNAME discovery wired in, generated sub-clients (`cf.data`, `cf.client`, `cf.auth`, `cf.notifier`), per-call `location=` override, `with_location()` clones that share connections when the cluster is explicit or unchanged and re-discover otherwise, `channel_for()`, context-manager lifecycle, and a `transport=` seam for test doubles.

## Related issues

- Closes #36 — v6: transport — endpoint resolution, channels, TLS, retries
- Closes #37 — v6: auth & tenancy — API-key credential, location metadata, with_location()
- Closes #38 — v6: typed error hierarchy mapped from gRPC status codes
- Closes #39 — v6: Clappform client class — constructor, sub-client wiring, lifecycle
- Implements #53 — v6: DNS-based cluster discovery — derive cluster from the location's CNAME

## Tests

- tests/test_errors.py — full status→type table, context formatting, location-header and rollout hints
- tests/test_auth.py — metadata emission, protocol conformance, blank-key rejection, repr hygiene
- tests/test_client.py — constructor validation, endpoint variants/overrides, discovery wiring, with_location sharing + re-discovery semantics, lifecycle ownership
- tests/test_transport_grpc.py — real in-process gRPC server: metadata seen server-side, streaming, NOT_FOUND/UNIMPLEMENTED/DEADLINE/unreachable translation
- `ruff check .`, `mypy src/clappform tools` (210 files), `pytest` (76 tests) passing locally

## Notes

- #53 is now delivered except its docs criterion (quickstart leading with location-only construction), which lands with the docs work (#48) — hence `Implements`, not `Closes`.
- Host prefixes (`data`/`client`/`auth`/`notifier`) and port 443 are the convention map from the design; #43 tracks confirming both against the real clusters — `endpoints=` covers any deviation meanwhile.
- Known behavior: cross-cluster `with_location()` clones inherit `endpoints=` overrides; and a custom `transport=` with omitted `cluster` still performs discovery (the value feeds repr and error context).
- Follow-up: LocalMock (#44) plugs into the `transport=` seam added here.