### PR TITLE
chore: add Python 3.14 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
## Summary

- Extends the test matrix to Python 3.14 on both Linux and Windows; the support policy is every Python from 3.10 up.
- Adds the 3.14 trove classifier so PyPI metadata matches what CI verifies.

## Notes

- `requires-python` stays `>=3.10` (no upper bound), so 3.15+ will install fine — the matrix just pins what we actively verify.