### PR TITLE
feat: JSON data-plane codec and LocalMock transport double

### DIFF
--- a/src/clappform/_codec.py
+++ b/src/clappform/_codec.py
@@ -1,0 +1,191 @@
+"""Data-plane JSON codec: records <-> bytes, with type normalisation.
+
+This is the encoding used by every DataFrame flow. It is deliberately
+pandas-independent — it speaks *records* (lists of plain dicts) in and out, so
+pandas is only ever applied at the very edge (``DataFrame(records)`` /
+``df.to_dict("records")``) and alternative surfaces (polars, Arrow) can be
+added without reworking the flows here.
+
+The wire carries result-set data in opaque ``bytes`` fields
+(``InsertRequest.data``, ``AggregateResponse.data``, update/delete payloads).
+Today those bytes are JSON; a columnar Arrow format is planned as an additive
+branch. To keep that additive, the read side is structured around a
+``(format, bytes)`` pair rather than assuming "bytes are always JSON": callers
+above this module pass the format the server reported, and only the
+``ChunkFormat.JSON`` branch is wired up here.
+
+Encoding rules (mirroring what the gateway's JSON handling expects):
+
+* ``NaN`` / ``NaT`` / ``None`` -> JSON ``null``.
+* ``datetime`` / ``date`` -> ISO-8601 strings.
+* Mongo Extended JSON v2 forms in *incoming* data (``{"$oid": ...}``,
+  ``{"$date": ...}``) are parsed to plain Python types so a round-trip does
+  not leave wrapper dicts in user DataFrames.
+* ``_id`` is kept as an ordinary column on the way in, so a read -> mutate ->
+  update round-trip can key on it without special handling.
+
+Uploads are chunked at ``DEFAULT_CHUNK_ROWS`` rows, matching 5.x behaviour, so
+a failed chunk is retryable at the flow level rather than re-sending the whole
+frame.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Iterator, Mapping
+from datetime import date, datetime, timezone
+from enum import Enum
+from typing import Any
+
+Record = dict[str, Any]
+
+DEFAULT_CHUNK_ROWS = 2500
+
+
+class ChunkFormat(str, Enum):
+    """Wire format of a data chunk's ``bytes`` payload.
+
+    Only ``JSON`` is decoded today. ``ARROW_IPC`` is reserved so the read path
+    can branch on the server-reported format once an Arrow output surface
+    ships, without changing this module's shape.
+    """
+
+    JSON = "json"
+    ARROW_IPC = "arrow_ipc"
+
+
+def _normalise_value(value: Any) -> Any:
+    """Convert one Python value to its JSON-serialisable form.
+
+    ``NaN``/``NaT`` collapse to ``None``; datetimes become ISO-8601 strings;
+    containers are normalised recursively so nested frames encode correctly.
+    """
+    if value is None:
+        return None
+    if isinstance(value, float):
+        # Covers both plain float NaN and pandas NaT/NA, which compare unequal
+        # to themselves. isnan rejects non-floats, so guard on float first.
+        if math.isnan(value):
+            return None
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(k): _normalise_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalise_value(v) for v in value]
+    # pandas NaT / NA and numpy NaN are floats-that-lie or singletons; catch the
+    # "not equal to itself" ones that slipped past the float branch (e.g. NaT).
+    if value != value:  # noqa: PLR0124 -- NaN/NaT sentinel check
+        return None
+    return value
+
+
+def _parse_extended_json(value: Any) -> Any:
+    """Collapse Mongo Extended JSON v2 wrappers to plain Python values.
+
+    ``{"$oid": "..."}`` becomes the hex string; ``{"$date": ...}`` becomes an
+    ISO-8601 string (the value is already ISO-8601 or epoch-ms per the v2
+    spec — epoch-ms is converted, strings pass through). Anything that is not a
+    recognised wrapper is returned structurally unchanged.
+    """
+    if isinstance(value, list):
+        return [_parse_extended_json(v) for v in value]
+    if not isinstance(value, dict):
+        return value
+    if len(value) == 1:
+        key, inner = next(iter(value.items()))
+        if key == "$oid" and isinstance(inner, str):
+            return inner
+        if key == "$date":
+            if isinstance(inner, dict) and "$numberLong" in inner:
+                inner = inner["$numberLong"]
+            if isinstance(inner, (int, str)) and not isinstance(inner, bool):
+                try:
+                    millis = int(inner)
+                except (TypeError, ValueError):
+                    return inner
+                return datetime.fromtimestamp(millis / 1000, tz=timezone.utc).isoformat()
+            return inner
+    return {k: _parse_extended_json(v) for k, v in value.items()}
+
+
+def records_to_bytes(records: Iterable[Record]) -> bytes:
+    """Encode a batch of records as a single JSON array of objects."""
+    normalised = [_normalise_value(dict(record)) for record in records]
+    return json.dumps(normalised, separators=(",", ":")).encode("utf-8")
+
+
+def chunk_records(
+    records: Iterable[Record],
+    chunk_rows: int = DEFAULT_CHUNK_ROWS,
+) -> Iterator[bytes]:
+    """Yield JSON-encoded chunks of at most ``chunk_rows`` records each.
+
+    Empty input yields nothing (no empty chunk is sent). A non-positive
+    ``chunk_rows`` is a caller error.
+    """
+    if chunk_rows <= 0:
+        raise ValueError(f"chunk_rows must be positive, got {chunk_rows}")
+    batch: list[Record] = []
+    for record in records:
+        batch.append(record)
+        if len(batch) >= chunk_rows:
+            yield records_to_bytes(batch)
+            batch = []
+    if batch:
+        yield records_to_bytes(batch)
+
+
+def bytes_to_records(data: bytes, fmt: ChunkFormat = ChunkFormat.JSON) -> list[Record]:
+    """Decode one chunk's ``bytes`` payload into records.
+
+    Extended JSON v2 wrappers are collapsed to plain values. An empty payload
+    (server sends ``b""`` for an empty result) decodes to no records.
+    """
+    if fmt is not ChunkFormat.JSON:
+        raise NotImplementedError(
+            f"decoding {fmt.value!r} chunks is not supported yet; "
+            "only JSON result data is handled by this client version"
+        )
+    if not data:
+        return []
+    decoded = json.loads(data)
+    if isinstance(decoded, dict):
+        decoded = [decoded]
+    if not isinstance(decoded, list):
+        raise ValueError(
+            f"expected a JSON array or object in result data, got {type(decoded).__name__}"
+        )
+    records: list[Record] = []
+    for item in decoded:
+        parsed = _parse_extended_json(item)
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"expected result rows to be objects, got {type(parsed).__name__}"
+            )
+        records.append(parsed)
+    return records
+
+
+def records_from_chunks(
+    chunks: Iterable[tuple[ChunkFormat, bytes]],
+) -> Iterator[Record]:
+    """Flatten a stream of ``(format, bytes)`` chunks into records.
+
+    This is the read-side seam the Arrow path plugs into: an ``ARROW_IPC``
+    branch becomes a new case here, not a rewrite of every caller.
+    """
+    for fmt, data in chunks:
+        yield from bytes_to_records(data, fmt)
+
+
+def encode_elastic_pipeline(pipeline: Any) -> bytes:
+    """Encode an Elastic-backed pipeline (Elastic DSL) as JSON bytes.
+
+    Mongo-backed collections expect a BSON-encoded pipeline instead; that
+    encoding is not handled here and is applied by the read layer when it
+    resolves the collection's storage backend.
+    """
+    return json.dumps(_normalise_value(pipeline), separators=(",", ":")).encode("utf-8")

--- a/src/clappform/testing/__init__.py
+++ b/src/clappform/testing/__init__.py
@@ -1,9 +1,13 @@
 """Test doubles for the Clappform client.
 
-This package will provide ``LocalMock``, a transport double that serves
-canned responses and records calls, so pipelines can be tested without
-infrastructure. The transport seam it plugs into lives in
-:mod:`clappform._runtime`.
+:class:`LocalMock` is a transport double that plugs into
+``Clappform(transport=LocalMock())``. It serves canned responses, records
+calls for assertions, and can seed collections so DataFrame round-trips run
+without infrastructure — used by our tests, by customers testing pipelines,
+and by ``examples/`` so the documented examples actually execute. The
+transport seam it implements lives in :mod:`clappform._runtime`.
 """
 
-__all__: list[str] = []
+from clappform.testing._local_mock import LocalMock, RecordedCall
+
+__all__ = ["LocalMock", "RecordedCall"]

--- a/src/clappform/testing/_local_mock.py
+++ b/src/clappform/testing/_local_mock.py
@@ -1,0 +1,305 @@
+"""``LocalMock`` — an in-process transport double for the Clappform client.
+
+``LocalMock`` implements the :class:`~clappform._runtime.Caller` protocol, so
+it plugs straight into ``Clappform(transport=LocalMock())`` and every generated
+service method works against it with no network and no infrastructure.
+
+It offers two layers:
+
+* **Explicit stubs** — :meth:`LocalMock.on` registers a canned response, a
+  handler callable, or (for streaming RPCs) an iterable of responses, keyed by
+  the full gRPC method path. This works for *any* RPC in the client.
+* **A seedable data-plane store** — :meth:`LocalMock.seed` loads records into a
+  named collection, and built-in handlers for the core data RPCs
+  (``AggregateStream``, ``InsertSingle``/``InsertMany``, ``UpdateMany`` by
+  ``_id``, the delete RPCs and ``Clear``) read and mutate that store through the
+  same JSON codec the real client uses. That is what lets a
+  read -> mutate -> update round-trip run end-to-end in tests and in
+  ``examples/``. An explicit stub for a method always wins over the built-in
+  handler.
+
+Every call is recorded on :attr:`LocalMock.calls` for assertions.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from clappform import _codec
+from clappform._errors import ClappformError
+from clappform._runtime import CallKind
+
+# A stub is a plain response, a callable taking the request, or (for streaming
+# outputs) an iterable of responses / a callable returning one.
+Handler = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class RecordedCall:
+    """One invocation seen by the mock, captured for assertions."""
+
+    kind: CallKind
+    method: str
+    request: Any
+    timeout: float | None
+    metadata: tuple[tuple[str, str], ...] | None
+    location: str | None
+
+
+class LocalMock:
+    """Transport double: canned responses, a data store, and call recording."""
+
+    def __init__(self) -> None:
+        self.calls: list[RecordedCall] = []
+        self._stubs: dict[str, Any] = {}
+        self._store: dict[str, list[_codec.Record]] = {}
+        self._oids = itertools.count(1)
+        self._closed = False
+
+    # -- configuration ---------------------------------------------------
+
+    def on(self, method: str, response: Any) -> LocalMock:
+        """Register a canned ``response`` for a full gRPC ``method`` path.
+
+        ``response`` may be a response message, a callable ``handler(request)``
+        returning one, or — for a streaming-output RPC — an iterable of
+        response messages (or a callable returning such an iterable). Returns
+        ``self`` so registrations chain. Registering the same method twice
+        replaces the earlier stub.
+        """
+        self._stubs[method] = response
+        return self
+
+    def seed(self, collection: str, records: Iterable[_codec.Record]) -> LocalMock:
+        """Load ``records`` into ``collection``'s in-memory store (replacing it).
+
+        Each record without an ``_id`` is given a synthetic one so update and
+        delete round-trips have a stable key. Returns ``self`` for chaining.
+        """
+        stored: list[_codec.Record] = []
+        for record in records:
+            row = dict(record)
+            if "_id" not in row or row["_id"] is None:
+                row["_id"] = self._next_oid()
+            stored.append(row)
+        self._store[collection] = stored
+        return self
+
+    def records(self, collection: str) -> list[_codec.Record]:
+        """A copy of the records currently stored for ``collection``."""
+        return [dict(row) for row in self._store.get(collection, [])]
+
+    def reset(self) -> None:
+        """Clear recorded calls, stubs and the data store."""
+        self.calls.clear()
+        self._stubs.clear()
+        self._store.clear()
+
+    def close(self) -> None:
+        """Mark the mock closed, matching the transport's teardown contract."""
+        self._closed = True
+
+    # -- Caller protocol -------------------------------------------------
+
+    def invoke(
+        self,
+        kind: CallKind,
+        method: str,
+        request: Any,
+        request_cls: type,
+        response_cls: type,
+        *,
+        timeout: float | None = None,
+        metadata: tuple[tuple[str, str], ...] | None = None,
+        location: str | None = None,
+    ) -> Any:
+        if self._closed:
+            raise ClappformError("client is closed", method=method)
+        materialised = list(request) if kind.startswith("stream") else request
+        self.calls.append(
+            RecordedCall(kind, method, materialised, timeout, metadata, location)
+        )
+
+        if method in self._stubs:
+            return self._dispatch_stub(kind, method, materialised, response_cls)
+
+        handler = _DATA_HANDLERS.get(method)
+        if handler is not None:
+            return handler(self, kind, materialised, response_cls)
+
+        raise ClappformError(
+            f"LocalMock has no response for {method!r}; register one with "
+            f".on({method!r}, ...) or seed a collection for the data RPCs",
+            method=method,
+        )
+
+    def _dispatch_stub(
+        self, kind: CallKind, method: str, request: Any, response_cls: type
+    ) -> Any:
+        stub = self._stubs[method]
+        streaming_out = kind.endswith("_stream")
+        is_handler = callable(stub) and not isinstance(stub, response_cls)
+        result = stub(request) if is_handler else stub
+        if streaming_out:
+            if isinstance(result, (str, bytes)) or not isinstance(result, Iterable):
+                raise ClappformError(
+                    f"stub for streaming method {method!r} must be an iterable of "
+                    f"responses, got {type(result).__name__}",
+                    method=method,
+                )
+            return iter(result)
+        if isinstance(result, Iterator):
+            # A stub returned an iterator for a unary-output RPC: take the
+            # first item so a single canned response still works.
+            return next(result)
+        return result
+
+    # -- data-plane store helpers ---------------------------------------
+
+    def _next_oid(self) -> str:
+        return f"mock-oid-{next(self._oids)}"
+
+    def _collection_of(self, request: Any) -> str:
+        collection = getattr(request, "collection", "")
+        if not collection:
+            raise ClappformError(
+                "LocalMock data handlers require a 'collection' on the request"
+            )
+        return collection
+
+
+def _handle_aggregate_stream(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Iterator[Any]:
+    """Serve a collection's seeded records as AggregateStream chunks."""
+    collection = mock._collection_of(request)
+    records = mock._store.get(collection, [])
+    total = len(records)
+    batch_size = getattr(request, "batch_size", 0) or _codec.DEFAULT_CHUNK_ROWS
+
+    def _chunks() -> Iterator[Any]:
+        if not records:
+            yield response_cls(data=b"[]", total=0, total_sent=0)
+            return
+        sent = 0
+        for start in range(0, total, batch_size):
+            chunk = records[start : start + batch_size]
+            sent += len(chunk)
+            yield response_cls(
+                data=_codec.records_to_bytes(chunk),
+                total=total,
+                total_sent=sent,
+            )
+
+    return _chunks()
+
+
+def _handle_insert(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Append decoded records to the store, assigning ids; report counts.
+
+    Handles ``InsertSingle`` (unary-unary) and ``InsertMany`` (stream-stream).
+    For the stream case the recorded request is a list of ``InsertRequest`` and
+    one ``InsertResponse`` is yielded per request message, matching the real
+    bidi transport; the unary case returns a single response.
+    """
+    requests = request if isinstance(request, list) else [request]
+
+    def _apply(req: Any) -> Any:
+        collection = mock._collection_of(req)
+        store = mock._store.setdefault(collection, [])
+        oids: list[str] = []
+        for record in _codec.bytes_to_records(req.data):
+            row = dict(record)
+            if "_id" not in row or row["_id"] is None:
+                row["_id"] = mock._next_oid()
+            store.append(row)
+            oids.append(str(row["_id"]))
+        return response_cls(processed_count=len(oids), oids=oids)
+
+    if kind.endswith("_stream"):
+        return iter([_apply(req) for req in requests])
+    return _apply(requests[0])
+
+
+def _build_response(response_cls: type, **fields: Any) -> Any:
+    """Construct a response, keeping only fields the message actually declares.
+
+    Data RPCs vary in their response shape (some return a data-bearing message,
+    some a plain ``Message{message}``); this lets one handler serve either
+    without hardcoding a schema the proto may not have.
+    """
+    declared = {f.name for f in response_cls.DESCRIPTOR.fields}  # type: ignore[attr-defined]
+    kept = {name: value for name, value in fields.items() if name in declared}
+    return response_cls(**kept)
+
+
+def _handle_update_many(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Apply field updates to stored rows matched by ``_id``.
+
+    ``UpdateMany`` is stream-unary, so ``request`` is a list of update messages;
+    every message's records are applied in order.
+    """
+    requests = request if isinstance(request, list) else [request]
+    collection = ""
+    for req in requests:
+        collection = mock._collection_of(req)
+        store = mock._store.setdefault(collection, [])
+        by_id = {str(row.get("_id")): row for row in store}
+        for record in _codec.bytes_to_records(req.data):
+            target = by_id.get(str(record.get("_id")))
+            if target is not None:
+                target.update({k: v for k, v in record.items() if k != "_id"})
+    store = mock._store.get(collection, [])
+    return _build_response(
+        response_cls,
+        data=_codec.records_to_bytes(store),
+        collection=collection,
+        message=f"updated {collection!r}",
+    )
+
+
+def _handle_delete_oids(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Remove stored rows whose ``_id`` is in the request's oids."""
+    collection = mock._collection_of(request)
+    store = mock._store.setdefault(collection, [])
+    targets = {str(oid) for oid in request.oids}
+    kept = [row for row in store if str(row.get("_id")) not in targets]
+    removed = len(store) - len(kept)
+    mock._store[collection] = kept
+    return _build_response(
+        response_cls,
+        total=len(kept),
+        total_sent=removed,
+        message=f"deleted {removed} rows",
+    )
+
+
+def _handle_clear(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Empty a collection's store."""
+    collection = mock._collection_of(request)
+    mock._store[collection] = []
+    return _build_response(response_cls, message=f"cleared {collection!r}")
+
+
+# Full method path -> built-in data-plane handler. Explicit .on() stubs win.
+_DATA_HANDLERS: dict[
+    str, Callable[[LocalMock, CallKind, Any, type], Any]
+] = {
+    "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream": _handle_aggregate_stream,
+    "/clappform.data.v1.insert.InsertManagement/InsertSingle": _handle_insert,
+    "/clappform.data.v1.insert.InsertManagement/InsertMany": _handle_insert,
+    "/clappform.data.v1.update.UpdateManagement/UpdateMany": _handle_update_many,
+    "/clappform.data.v1.delete.DeleteManagement/DeleteManyByOids": _handle_delete_oids,
+    "/clappform.data.v1.delete.DeleteManagement/Clear": _handle_clear,
+}

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,112 @@
+"""Data-plane JSON codec: encoding rules, round-trips, and error handling."""
+
+import json
+import math
+from datetime import date, datetime, timezone
+
+import pytest
+
+from clappform import _codec
+from clappform._codec import ChunkFormat
+
+
+def test_records_to_bytes_is_compact_json_array() -> None:
+    data = _codec.records_to_bytes([{"a": 1}, {"a": 2}])
+    assert data == b'[{"a":1},{"a":2}]'
+    assert json.loads(data) == [{"a": 1}, {"a": 2}]
+
+
+def test_nan_and_none_become_null() -> None:
+    data = _codec.records_to_bytes([{"x": float("nan"), "y": None, "z": 1.5}])
+    assert json.loads(data) == [{"x": None, "y": None, "z": 1.5}]
+
+
+def test_datetime_and_date_become_iso8601() -> None:
+    row = {"ts": datetime(2020, 1, 2, 3, 4, 5), "d": date(2021, 6, 7)}
+    assert json.loads(_codec.records_to_bytes([row])) == [
+        {"ts": "2020-01-02T03:04:05", "d": "2021-06-07"}
+    ]
+
+
+def test_nested_containers_are_normalised() -> None:
+    row = {"items": [{"v": float("nan")}, {"v": 2}], "meta": {"at": date(2020, 1, 1)}}
+    assert json.loads(_codec.records_to_bytes([row])) == [
+        {"items": [{"v": None}, {"v": 2}], "meta": {"at": "2020-01-01"}}
+    ]
+
+
+def test_id_is_preserved_across_round_trip() -> None:
+    records = [{"_id": "abc", "amount": 10}]
+    decoded = _codec.bytes_to_records(_codec.records_to_bytes(records))
+    assert decoded == [{"_id": "abc", "amount": 10}]
+
+
+def test_bytes_to_records_accepts_single_object() -> None:
+    assert _codec.bytes_to_records(b'{"a":1}') == [{"a": 1}]
+
+
+def test_empty_payload_decodes_to_no_records() -> None:
+    assert _codec.bytes_to_records(b"") == []
+
+
+def test_extended_json_oid_and_date_are_collapsed() -> None:
+    payload = b'[{"_id":{"$oid":"deadbeef"},"created":{"$date":"2021-05-06T00:00:00Z"}}]'
+    assert _codec.bytes_to_records(payload) == [
+        {"_id": "deadbeef", "created": "2021-05-06T00:00:00Z"}
+    ]
+
+
+def test_extended_json_date_epoch_millis_is_converted() -> None:
+    millis = int(datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    payload = json.dumps([{"d": {"$date": {"$numberLong": str(millis)}}}]).encode()
+    (record,) = _codec.bytes_to_records(payload)
+    assert record["d"].startswith("2021-01-01T00:00:00")
+
+
+def test_chunk_records_splits_on_row_count() -> None:
+    chunks = list(_codec.chunk_records(({"i": i} for i in range(5)), chunk_rows=2))
+    assert [len(_codec.bytes_to_records(c)) for c in chunks] == [2, 2, 1]
+
+
+def test_chunk_records_empty_input_yields_nothing() -> None:
+    assert list(_codec.chunk_records([])) == []
+
+
+def test_chunk_records_rejects_non_positive_size() -> None:
+    with pytest.raises(ValueError, match="chunk_rows must be positive"):
+        list(_codec.chunk_records([{"a": 1}], chunk_rows=0))
+
+
+def test_records_from_chunks_flattens_format_pairs() -> None:
+    chunks = [
+        (ChunkFormat.JSON, b'[{"a":1}]'),
+        (ChunkFormat.JSON, b'[{"a":2},{"a":3}]'),
+    ]
+    assert list(_codec.records_from_chunks(chunks)) == [{"a": 1}, {"a": 2}, {"a": 3}]
+
+
+def test_arrow_format_is_not_yet_decodable() -> None:
+    with pytest.raises(NotImplementedError, match="arrow_ipc"):
+        _codec.bytes_to_records(b"...", ChunkFormat.ARROW_IPC)
+
+
+def test_non_array_non_object_payload_is_rejected() -> None:
+    with pytest.raises(ValueError, match="expected a JSON array or object"):
+        _codec.bytes_to_records(b"42")
+
+
+def test_array_of_scalars_is_rejected() -> None:
+    with pytest.raises(ValueError, match="expected result rows to be objects"):
+        _codec.bytes_to_records(b"[1,2,3]")
+
+
+def test_encode_elastic_pipeline_normalises_and_serialises() -> None:
+    encoded = _codec.encode_elastic_pipeline([{"match": {"ts": date(2020, 1, 1)}}])
+    assert json.loads(encoded) == [{"match": {"ts": "2020-01-01"}}]
+
+
+def test_float_nan_helper_is_json_null_not_string() -> None:
+    # Regression guard: NaN must not leak through as the literal "NaN" that
+    # json.dumps would otherwise emit for an unguarded float.
+    data = _codec.records_to_bytes([{"x": math.nan}])
+    assert b"NaN" not in data

--- a/tests/test_local_mock.py
+++ b/tests/test_local_mock.py
@@ -1,0 +1,191 @@
+"""LocalMock transport double: stubs, call recording, and data round-trips.
+
+Drives the mock through the real ``Clappform`` client and generated service
+layer, which is how customers and ``examples/`` use it.
+"""
+
+import pytest
+
+from clappform import Clappform, ClappformError, _codec
+from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+from clappform.gen.clappform.data.v1.insert import insert_pb2
+from clappform.gen.clappform.data.v1.update import update_pb2
+from clappform.testing import LocalMock, RecordedCall
+
+
+@pytest.fixture
+def cf():
+    mock = LocalMock()
+    client = Clappform("acme", "qa", api_key="test-key", transport=mock)
+    yield client, mock
+    client.close()
+
+
+def test_stub_serves_canned_unary_response() -> None:
+    mock = LocalMock()
+    mock.on(
+        "/clappform.data.v1.insert.InsertManagement/InsertSingle",
+        insert_pb2.InsertResponse(processed_count=7, oids=["x"]),
+    )
+    cf = Clappform("acme", "qa", api_key="k", transport=mock)
+    resp = cf.data.insert.insert_single(collection="orders", data=b"[]")
+    assert resp.processed_count == 7
+    assert list(resp.oids) == ["x"]
+
+
+def test_stub_handler_receives_request(cf) -> None:
+    client, mock = cf
+
+    def handler(request):
+        assert request.collection == "orders"
+        return insert_pb2.InsertResponse(processed_count=1, oids=["from-handler"])
+
+    mock.on("/clappform.data.v1.insert.InsertManagement/InsertSingle", handler)
+    resp = client.data.insert.insert_single(collection="orders", data=b"[]")
+    assert list(resp.oids) == ["from-handler"]
+
+
+def test_calls_are_recorded_with_location(cf) -> None:
+    client, mock = cf
+    mock.on(
+        "/clappform.data.v1.insert.InsertManagement/InsertSingle",
+        insert_pb2.InsertResponse(processed_count=0),
+    )
+    client.data.insert.insert_single(collection="orders", data=b"[]")
+    (call,) = mock.calls
+    assert isinstance(call, RecordedCall)
+    assert call.method.endswith("/InsertSingle")
+    assert call.location == "acme"  # injected by the bound caller
+
+
+def test_unknown_method_raises_helpful_error(cf) -> None:
+    client, _mock = cf
+    with pytest.raises(ClappformError, match="no response for"):
+        client.data.change_request.request_change(collection="c", data=b"[]")
+
+
+def test_seeded_read_streams_records(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"order_id": 1, "amount": 10.0}, {"order_id": 2, "amount": 20.0}])
+    records = []
+    for chunk in client.data.aggregate.aggregate_stream(collection="orders"):
+        records.extend(_codec.bytes_to_records(chunk.data))
+    assert [r["order_id"] for r in records] == [1, 2]
+    assert all("_id" in r for r in records)  # synthetic ids assigned on seed
+
+
+def test_seeded_read_respects_batch_size(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"i": i} for i in range(5)])
+    sizes = [
+        len(_codec.bytes_to_records(chunk.data))
+        for chunk in client.data.aggregate.aggregate_stream(
+            collection="orders", batch_size=2
+        )
+    ]
+    assert sizes == [2, 2, 1]
+
+
+def test_empty_collection_reads_one_empty_chunk(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [])
+    chunks = list(client.data.aggregate.aggregate_stream(collection="orders"))
+    assert len(chunks) == 1
+    assert _codec.bytes_to_records(chunks[0].data) == []
+
+
+def test_insert_single_appends_and_assigns_ids(cf) -> None:
+    client, mock = cf
+    resp = client.data.insert.insert_single(
+        collection="orders", data=_codec.records_to_bytes([{"amount": 5}])
+    )
+    assert resp.processed_count == 1
+    stored = mock.records("orders")
+    assert len(stored) == 1
+    assert stored[0]["amount"] == 5
+    assert stored[0]["_id"] == list(resp.oids)[0]
+
+
+def test_insert_many_stream_yields_response_per_request(cf) -> None:
+    client, mock = cf
+    requests = [
+        insert_pb2.InsertRequest(
+            collection="orders", data=_codec.records_to_bytes([{"n": 1}])
+        ),
+        insert_pb2.InsertRequest(
+            collection="orders", data=_codec.records_to_bytes([{"n": 2}, {"n": 3}])
+        ),
+    ]
+    responses = list(client.data.insert.insert_many(iter(requests)))
+    assert [r.processed_count for r in responses] == [1, 2]
+    assert len(mock.records("orders")) == 3
+
+
+def test_read_mutate_update_round_trip(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"order_id": 1, "status": "open"}])
+    # read
+    (record,) = _codec.bytes_to_records(
+        next(client.data.aggregate.aggregate_stream(collection="orders")).data
+    )
+    # mutate and update by _id (UpdateMany is stream-unary)
+    record["status"] = "closed"
+    client.data.update.update_many(
+        [
+            update_pb2.UpdateRequestByOid(
+                collection="orders", data=_codec.records_to_bytes([record])
+            )
+        ]
+    )
+    assert mock.records("orders")[0]["status"] == "closed"
+
+
+def test_delete_by_oids_removes_matching_rows(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"_id": "a"}, {"_id": "b"}, {"_id": "c"}])
+    client.data.delete.delete_many_by_oids(collection="orders", oids=["a", "c"])
+    assert [r["_id"] for r in mock.records("orders")] == ["b"]
+
+
+def test_clear_empties_collection(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"_id": "a"}, {"_id": "b"}])
+    client.data.delete.clear(collection="orders")
+    assert mock.records("orders") == []
+
+
+def test_explicit_stub_overrides_builtin_data_handler(cf) -> None:
+    client, mock = cf
+    mock.seed("orders", [{"_id": "a"}])
+    mock.on(
+        "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream",
+        [aggregate_pb2.AggregateResponse(data=b'[{"stubbed":true}]', total=1)],
+    )
+    (chunk,) = list(client.data.aggregate.aggregate_stream(collection="orders"))
+    assert _codec.bytes_to_records(chunk.data) == [{"stubbed": True}]
+
+
+def test_streaming_stub_must_be_iterable(cf) -> None:
+    client, mock = cf
+    mock.on(
+        "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream",
+        aggregate_pb2.AggregateResponse(data=b"[]"),  # a bare message, not a list
+    )
+    with pytest.raises(ClappformError, match="must be an iterable"):
+        list(client.data.aggregate.aggregate_stream(collection="orders"))
+
+
+def test_reset_clears_state() -> None:
+    mock = LocalMock()
+    mock.seed("orders", [{"_id": "a"}]).on("/x/Y", object())
+    mock.reset()
+    assert mock.calls == []
+    assert mock.records("orders") == []
+
+
+def test_closed_mock_rejects_calls() -> None:
+    mock = LocalMock()
+    client = Clappform("acme", "qa", api_key="k", transport=mock)
+    mock.close()  # a caller-owned transport is closed directly, not via client
+    with pytest.raises(ClappformError, match="client is closed"):
+        client.data.insert.insert_single(collection="orders", data=b"[]")


### PR DESCRIPTION
## Summary

- Add `_codec.py`, the pandas-independent data-plane encoding used by all DataFrame flows: records ↔ JSON bytes, chunked at ~2500 rows. NaN/NaT/None → JSON null, datetimes → ISO-8601, `_id` kept as a regular column for read/mutate/update round-trips, and incoming Mongo Extended JSON v2 (`$oid`, `$date`) collapsed to plain values.
- Structure the read side around `(format, bytes)` chunk pairs so a future columnar format lands as a branch, not a rewrite.
- Add `clappform.testing.LocalMock`, a transport double implementing the `Caller` protocol — plugs into `Clappform(transport=LocalMock())`, serves canned responses (`on()`), records calls, and backs the core data RPCs with a seedable in-memory store so round-trips run without infrastructure.

## Related issues

- Closes #40 — v6: JSON codec — records <-> bytes, type handling
- Closes #44 — v6: clappform.testing.LocalMock — transport double

## Tests

- `tests/test_codec.py` — encoding rules, chunking, Extended JSON, malformed-payload errors.
- `tests/test_local_mock.py` — canned stubs, handler callables, call recording, seeded read/insert/update/delete round-trips, batch sizing, stub-over-handler precedence, error paths (driven through the real client + generated services).
- `python -m ruff check .`, `python -m mypy src/clappform tools`, `python -m pytest -q` all passing locally (110 tests).

## Notes

- Design doc: `DESIGN.md` §6 / §6.2 (DataFrame integration, `ReadResult` seam), §8 (testing strategy); `planning/pypi-arrow-handoff.md` §3 (format-aware codec).
- Scope boundary: `_codec.py` handles the JSON **data** payloads (the `data` bytes fields all DataFrame flows use) and JSON-encoded (Elastic) pipeline encoding. **Follow-up:** BSON pipeline encoding for Mongo-backed collections is deferred — it needs a dependency decision (no `bson`/`pymongo` in the minimal core deps) and belongs with the collection/read layer that resolves a collection's storage backend.
- The `LocalMock` data store implements the core round-trip RPCs (`AggregateStream`, `InsertSingle`/`InsertMany`, `UpdateMany` by `_id`, `DeleteManyByOids`, `Clear`); other data mutations (by-field/by-query variants) are served via explicit `on()` stubs, which is the universal mechanism for any RPC.
