### PR TITLE
feat(data): collection/query handles and DataFrame flows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,9 @@ ignore_errors = true
 module = "clappform.services.*"
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = "pandas.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/clappform/__init__.py
+++ b/src/clappform/__init__.py
@@ -16,6 +16,7 @@ from clappform._errors import (
 )
 from clappform._proto_version import __proto_version__
 from clappform._transport import DEFAULT_RETRIES, RetryPolicy
+from clappform.dataframes import CollectionHandle, QueryHandle, ReadResult
 
 __version__ = "6.0.0a0"
 
@@ -25,10 +26,13 @@ __all__ = [
     "AuthenticationError",
     "Clappform",
     "ClappformError",
+    "CollectionHandle",
     "ConfigurationError",
     "ConflictError",
     "Credentials",
     "InvalidRequestError",
+    "QueryHandle",
+    "ReadResult",
     "NotFoundError",
     "NotSupportedError",
     "PermissionDeniedError",

--- a/src/clappform/_client.py
+++ b/src/clappform/_client.py
@@ -8,9 +8,9 @@ clone for another tenant, sharing connections and configuration.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from clappform import _discovery, _runtime
+from clappform import _discovery, _resolve, _runtime, dataframes
 from clappform._auth import ApiKey, Credentials
 from clappform._errors import ConfigurationError
 from clappform._transport import (
@@ -20,6 +20,12 @@ from clappform._transport import (
     resolve_endpoints,
 )
 from clappform.services import API_FAMILIES
+
+if TYPE_CHECKING:
+    from clappform.services.auth import AuthAPI
+    from clappform.services.client import ClientAPI
+    from clappform.services.data import DataAPI
+    from clappform.services.notifier import NotifierAPI
 
 
 class _BoundCaller:
@@ -54,6 +60,15 @@ class Clappform:
     All configuration is explicit constructor input: the library reads no
     config files and no environment variables.
     """
+
+    # Sub-clients are bound dynamically from API_FAMILIES in _bind_services;
+    # these annotations give the generated surface (cf.data, cf.client, ...)
+    # static types without hand-maintaining the binding.
+    if TYPE_CHECKING:
+        data: DataAPI
+        client: ClientAPI
+        auth: AuthAPI
+        notifier: NotifierAPI
 
     def __init__(
         self,
@@ -104,12 +119,33 @@ class Clappform:
             )
             self._owns_transport = True
 
+        self._resolver = _resolve.Resolver(self)
         self._bind_services()
 
     def _bind_services(self) -> None:
         caller = _BoundCaller(self._transport, self.location)
         for family, api_cls in API_FAMILIES.items():
             setattr(self, family, api_cls(caller))
+        self._attach_dataframe_handles()
+
+    def _attach_dataframe_handles(self) -> None:
+        """Hang the DataFrame entry points off the generated ``data`` API.
+
+        ``cf.data.collection(ref)`` / ``cf.data.query(ref)`` are the flagship
+        surface, but ``data`` is generated ("do not edit"), so they are
+        attached here rather than baked into the codegen. Each closes over this
+        client so the handle inherits the location and shares the resolver
+        cache; the raw generated RPCs on ``cf.data`` are untouched.
+        """
+
+        def collection(ref: str) -> dataframes.CollectionHandle:
+            return dataframes.CollectionHandle(self, ref)
+
+        def query(ref: str) -> dataframes.QueryHandle:
+            return dataframes.QueryHandle(self, ref)
+
+        self.data.collection = collection  # type: ignore[attr-defined]
+        self.data.query = query  # type: ignore[attr-defined]
 
     def with_location(self, location: str) -> Clappform:
         """A clone bound to another tenant, sharing connections when possible.

--- a/src/clappform/_codec.py
+++ b/src/clappform/_codec.py
@@ -181,11 +181,19 @@ def records_from_chunks(
         yield from bytes_to_records(data, fmt)
 
 
-def encode_elastic_pipeline(pipeline: Any) -> bytes:
-    """Encode an Elastic-backed pipeline (Elastic DSL) as JSON bytes.
+def encode_pipeline(pipeline: Any) -> bytes:
+    """Encode an aggregation pipeline as JSON bytes for the wire.
 
-    Mongo-backed collections expect a BSON-encoded pipeline instead; that
-    encoding is not handled here and is applied by the read layer when it
-    resolves the collection's storage backend.
+    The pipeline goes across as JSON regardless of the collection's storage
+    backend: the server reads the bytes into a map and, for Mongo-backed
+    collections, converts that map to BSON itself; Elastic-backed collections
+    consume the JSON (Elastic DSL) directly. Values are normalised the same
+    way record data is (``NaN``/``NaT`` -> ``null``, datetimes -> ISO-8601), so
+    a pipeline referencing timestamps encodes consistently with the rows.
     """
     return json.dumps(_normalise_value(pipeline), separators=(",", ":")).encode("utf-8")
+
+
+# Retained alias: the pipeline encoding was originally named for the Elastic
+# path before it was confirmed to be the single JSON encoding for all backends.
+encode_elastic_pipeline = encode_pipeline

--- a/src/clappform/_resolve.py
+++ b/src/clappform/_resolve.py
@@ -1,0 +1,111 @@
+"""Slug/name -> UUID resolution for collections and saved queries.
+
+The data plane identifies collections and saved queries by UUID, but both
+entities also carry a human identifier — a ``slug`` for collections, a
+``name`` for saved queries — and that is what people remember. So the
+DataFrame entry points accept either: a string that already parses as a UUID
+is used as-is with zero overhead, and anything else is treated as a human
+identifier and resolved through the Client API on first use.
+
+Resolutions are cached per location on the owning client, so a slug costs one
+extra lookup per process, not per call. A cached UUID that later comes back
+``NOT_FOUND`` (the entity was recreated, or its slug remapped) is re-resolved
+once before the error is surfaced. An identifier that matches nothing raises
+:class:`NotFoundError`, naming both the identifier and the location searched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from clappform._errors import NotFoundError
+
+if TYPE_CHECKING:
+    from clappform._client import Clappform
+
+
+def is_uuid(ref: str) -> bool:
+    """Whether ``ref`` is a UUID string (any standard form) usable as-is.
+
+    Accepts the canonical hyphenated form and the other layouts
+    :class:`uuid.UUID` parses (braces, urn, bare hex); rejects everything
+    else, which is then treated as a slug/name to resolve.
+    """
+    try:
+        uuid.UUID(ref)
+    except (ValueError, AttributeError):
+        return False
+    return True
+
+
+class Resolver:
+    """Per-client slug/name -> UUID resolver, cached per location.
+
+    One instance is held by a :class:`~clappform._client.Clappform`; its
+    ``with_location`` clones share it, and the cache is keyed by location so a
+    slug resolved for one tenant is never reused for another.
+    """
+
+    __slots__ = ("_client", "_collections", "_queries")
+
+    def __init__(self, client: Clappform) -> None:
+        self._client = client
+        # location -> {slug/name: uuid}
+        self._collections: dict[str, dict[str, str]] = {}
+        self._queries: dict[str, dict[str, str]] = {}
+
+    def collection_id(self, ref: str, location: str) -> str:
+        """The UUID for a collection ``ref`` (slug or UUID) at ``location``."""
+        if is_uuid(ref):
+            return ref
+        return self._cached(self._collections, ref, location, self._lookup_collection)
+
+    def query_id(self, ref: str, location: str) -> str:
+        """The UUID for a saved query ``ref`` (name or UUID) at ``location``."""
+        if is_uuid(ref):
+            return ref
+        return self._cached(self._queries, ref, location, self._lookup_query)
+
+    def invalidate_collection(self, ref: str, location: str) -> None:
+        """Drop any cached collection UUID for ``ref`` at ``location``.
+
+        Called when a cached UUID comes back ``NOT_FOUND`` so the next use
+        re-resolves the slug rather than reusing a stale mapping.
+        """
+        self._collections.get(location, {}).pop(ref, None)
+
+    def invalidate_query(self, ref: str, location: str) -> None:
+        """Drop any cached saved-query UUID for ``ref`` at ``location``."""
+        self._queries.get(location, {}).pop(ref, None)
+
+    # -- internals -------------------------------------------------------
+
+    def _cached(self, cache, ref, location, lookup):
+        by_ref = cache.setdefault(location, {})
+        cached = by_ref.get(ref)
+        if cached is not None:
+            return cached
+        resolved = lookup(ref, location)
+        by_ref[ref] = resolved
+        return resolved
+
+    def _lookup_collection(self, slug: str, location: str) -> str:
+        for collection in self._client.client.collection.iter_get_all(location=location):
+            if collection.slug == slug:
+                return collection.id
+        raise NotFoundError(
+            f"no collection with slug {slug!r} found",
+            location=location,
+            cluster=self._client.cluster,
+        )
+
+    def _lookup_query(self, name: str, location: str) -> str:
+        for query in self._client.client.query.iter_get_all(location=location):
+            if query.name == name:
+                return query.id
+        raise NotFoundError(
+            f"no saved query named {name!r} found",
+            location=location,
+            cluster=self._client.cluster,
+        )

--- a/src/clappform/dataframes.py
+++ b/src/clappform/dataframes.py
@@ -1,0 +1,578 @@
+"""Collection and saved-query handles — the DataFrame-flavoured surface.
+
+This is the ergonomic layer people actually reach for:
+
+    col = cf.data.collection("sales_orders")   # slug or UUID (resolved in §_resolve)
+    df = col.read(where={"status": "open"}, fields=["id", "amount"], limit=1000)
+    col.append(df); col.update(df); col.upsert(df, on="order_id")
+
+A handle holds only ``(client, reference)`` — no connection, no state — and
+every flow runs over the streaming data RPCs through the client's transport.
+Reads go through :class:`ReadResult`, the seam future output surfaces
+(``to_polars``/``to_arrow``) plug into: ``read()`` is literally
+``fetch().to_pandas()``.
+
+Encoding lives in :mod:`clappform._codec` as records in / records out, so this
+module never touches JSON directly and pandas is applied only at the very edge
+(:meth:`ReadResult.to_pandas`). ``read()`` keeps ``_id`` as an ordinary column,
+so a read -> mutate -> ``update()`` round-trip keys on it with no special
+handling from the caller.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from clappform import _codec
+from clappform._codec import Record
+from clappform._errors import ClappformError, NotFoundError
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from clappform._client import Clappform
+
+ProgressCallback = Callable[[int], None]
+
+
+def _require_pandas() -> Any:
+    """Import pandas, turning the ImportError into an actionable message."""
+    try:
+        import pandas as pd
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ClappformError(
+            "pandas is required for DataFrame conversion; "
+            "install it with: pip install clappform[pandas]"
+        ) from exc
+    return pd
+
+
+def _records_from_frame(df: pd.DataFrame) -> list[Record]:
+    """Turn a DataFrame into plain records (the codec's input form).
+
+    ``to_dict("records")`` yields one dict per row with native Python scalars;
+    the codec then normalises ``NaN``/``NaT``/datetimes on encode, so nothing
+    pandas-specific leaks past this boundary.
+    """
+    return df.to_dict("records")
+
+
+class ReadResult:
+    """A lazily-materialised result set from ``AggregateStream``.
+
+    Wraps the stream of ``(format, bytes)`` chunks the server sends and exposes
+    it as records (:meth:`__iter__`, :meth:`iter_batches`) or a pandas frame
+    (:meth:`to_pandas`). It is single-pass: the underlying gRPC stream is
+    consumed once, so iterate or convert exactly one way. Materialising the
+    same result twice raises rather than silently returning an empty set.
+
+    Shipping this now (rather than returning a DataFrame straight from
+    ``read()``) is deliberate: ``to_polars`` / ``to_arrow`` / the Arrow
+    PyCapsule protocol land as new methods here without changing any existing
+    return type, and the batch-wise internals let a future Arrow reader map one
+    Arrow batch per gRPC chunk.
+    """
+
+    __slots__ = ("_chunks", "_consumed")
+
+    def __init__(self, chunks: Iterable[tuple[_codec.ChunkFormat, bytes]]) -> None:
+        self._chunks = iter(chunks)
+        self._consumed = False
+
+    def _claim(self) -> None:
+        if self._consumed:
+            raise ClappformError(
+                "this ReadResult has already been consumed; a result set streams "
+                "once — call read()/fetch() again for a fresh one"
+            )
+        self._consumed = True
+
+    def __iter__(self) -> Iterator[Record]:
+        """Yield every record across all chunks, one row at a time."""
+        self._claim()
+        return _codec.records_from_chunks(self._chunks)
+
+    def iter_batches(self) -> Iterator[list[Record]]:
+        """Yield one list of records per gRPC chunk (memory-bounded reads)."""
+        self._claim()
+        for fmt, data in self._chunks:
+            yield _codec.bytes_to_records(data, fmt)
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Materialise the whole result set as a pandas DataFrame.
+
+        ``_id`` stays an ordinary column so the frame round-trips through
+        :meth:`CollectionHandle.update`. An empty result yields an empty frame.
+        """
+        pd = _require_pandas()
+        records = list(self)
+        return pd.DataFrame.from_records(records)
+
+
+class _AggregateReader:
+    """Shared read machinery for collection and saved-query handles.
+
+    Both handles read through ``AggregateStream``; they differ only in which
+    request fields they fill (a collection sends ``collection`` + ``pipeline``,
+    a saved query sends ``query``). This centralises the streaming, the
+    ``(format, bytes)`` adaptation, and the stale-UUID re-resolution retry.
+    """
+
+    # Provided by the concrete handles (declared in their __slots__).
+    _client: Clappform
+    _location: str
+
+    def _stream(
+        self,
+        *,
+        collection: str | None,
+        pipeline: bytes | None,
+        query: str | None,
+        batch_size: int | None,
+        timeout: float | None,
+    ) -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+        responses = self._client.data.aggregate.aggregate_stream(
+            collection=collection,
+            pipeline=pipeline,
+            query=query,
+            batch_size=batch_size,
+            location=self._location,
+            timeout=timeout,
+        )
+        for response in responses:
+            # The stream carries only JSON today; the codec branches on the
+            # format so an Arrow chunk type slots in without changing callers.
+            yield _codec.ChunkFormat.JSON, response.data
+
+    def _read_reresolving(
+        self,
+        open_stream: Callable[[], Iterator[tuple[_codec.ChunkFormat, bytes]]],
+        on_stale: Callable[[], None],
+    ) -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+        """Open a read stream, re-resolving once if the id is stale.
+
+        ``AggregateStream`` is lazy: the request is not sent until the returned
+        iterator is first advanced, and the transport surfaces a server
+        ``NOT_FOUND`` as :class:`NotFoundError` at that point. So the first
+        chunk is pulled here to probe. If it fails ``NOT_FOUND``, ``on_stale``
+        drops the cached id, and a second stream is opened against the freshly
+        resolved id — this is the one re-resolution the slug contract promises.
+
+        The retry deliberately covers only a ``NOT_FOUND`` raised *before* any
+        row reaches the caller (the probe). Once the first chunk has been
+        handed out, retrying would replay already-delivered rows, so a
+        ``NOT_FOUND`` on a later chunk propagates unchanged rather than
+        silently duplicating data. A directly-supplied UUID has no cache entry,
+        so ``on_stale`` is a no-op and the second open simply fails the same way.
+        """
+        stream = open_stream()
+        try:
+            first = next(stream)
+        except StopIteration:
+            return
+        except NotFoundError:
+            on_stale()
+            yield from open_stream()
+            return
+        yield first
+        yield from stream
+
+
+def _compile_pipeline(
+    where: Mapping[str, Any] | None,
+    fields: Sequence[str] | None,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    """Compile ``where``/``fields``/``limit`` sugar into a Mongo pipeline.
+
+    These kwargs are purely client-side — the API never sees them. Each maps
+    to one stage in a plain aggregation pipeline (``$match`` / ``$project`` /
+    ``$limit``), producing exactly what an equivalent ``aggregate()`` call
+    would send. Order matches Mongo semantics: filter, then project, then cap.
+    """
+    pipeline: list[dict[str, Any]] = []
+    if where:
+        pipeline.append({"$match": dict(where)})
+    if fields:
+        pipeline.append({"$project": {field: 1 for field in fields}})
+    if limit is not None:
+        if limit < 0:
+            raise ValueError(f"limit must be non-negative, got {limit}")
+        pipeline.append({"$limit": limit})
+    return pipeline
+
+
+class CollectionHandle(_AggregateReader):
+    """A handle to one collection: reads, writes, and ad-hoc aggregation.
+
+    Obtained from ``cf.data.collection(ref)`` where ``ref`` is a slug or a
+    UUID (resolved on first use, cached per location). Holds nothing but the
+    client and the resolved collection id.
+    """
+
+    __slots__ = ("_client", "_ref", "_location", "_id")
+
+    def __init__(self, client: Clappform, ref: str) -> None:
+        self._client = client
+        self._ref = ref
+        self._location = client.location
+        self._id: str | None = None
+
+    @property
+    def collection_id(self) -> str:
+        """The resolved collection UUID (resolves + caches on first access)."""
+        if self._id is None:
+            self._id = self._client._resolver.collection_id(self._ref, self._location)
+        return self._id
+
+    def __repr__(self) -> str:
+        resolved = f" -> {self._id}" if self._id is not None else ""
+        return f"CollectionHandle({self._ref!r}{resolved}, location={self._location!r})"
+
+    # -- reads -----------------------------------------------------------
+
+    def fetch(
+        self,
+        *,
+        where: Mapping[str, Any] | None = None,
+        fields: Sequence[str] | None = None,
+        limit: int | None = None,
+        pipeline: Sequence[Mapping[str, Any]] | None = None,
+        batch_size: int | None = None,
+        timeout: float | None = None,
+    ) -> ReadResult:
+        """Stream the collection into a :class:`ReadResult`.
+
+        ``where``/``fields``/``limit`` are client-side sugar compiled into a
+        ``$match``/``$project``/``$limit`` pipeline. ``pipeline=`` supplies a
+        full aggregation pipeline instead and is mutually exclusive with the
+        sugar — passing both is a caller error.
+        """
+        if pipeline is not None and (where or fields or limit is not None):
+            raise ValueError("pass either pipeline= or the where/fields/limit sugar, not both")
+        stages = (
+            [dict(stage) for stage in pipeline]
+            if pipeline is not None
+            else _compile_pipeline(where, fields, limit)
+        )
+        encoded = _codec.encode_pipeline(stages)
+        chunks = self._read_with_retry(encoded, batch_size, timeout)
+        return ReadResult(chunks)
+
+    def read(
+        self,
+        *,
+        where: Mapping[str, Any] | None = None,
+        fields: Sequence[str] | None = None,
+        limit: int | None = None,
+        batch_size: int | None = None,
+        timeout: float | None = None,
+    ) -> pd.DataFrame:
+        """The whole collection (or a filtered slice) as a pandas DataFrame.
+
+        Exactly ``fetch(...).to_pandas()``. ``_id`` is kept as a column so the
+        frame can be mutated and passed straight to :meth:`update`.
+        """
+        return self.fetch(
+            where=where,
+            fields=fields,
+            limit=limit,
+            batch_size=batch_size,
+            timeout=timeout,
+        ).to_pandas()
+
+    def iter_batches(
+        self,
+        *,
+        where: Mapping[str, Any] | None = None,
+        fields: Sequence[str] | None = None,
+        limit: int | None = None,
+        batch_size: int | None = None,
+        timeout: float | None = None,
+    ) -> Iterator[list[Record]]:
+        """Stream records in memory-bounded batches (one list per gRPC chunk).
+
+        ``batch_size`` asks the server to cap each chunk's row count; the
+        client yields whatever chunking the server sends back.
+        """
+        return self.fetch(
+            where=where,
+            fields=fields,
+            limit=limit,
+            batch_size=batch_size,
+            timeout=timeout,
+        ).iter_batches()
+
+    def aggregate(
+        self,
+        pipeline: Sequence[Mapping[str, Any]],
+        *,
+        batch_size: int | None = None,
+        timeout: float | None = None,
+    ) -> pd.DataFrame:
+        """Run a caller-supplied aggregation pipeline, returning a DataFrame.
+
+        The pipeline is passed through untouched — use this for Elastic-backed
+        collections (whose DSL the ``where``/``fields`` sugar does not emit) or
+        any stage the sugar does not cover (``$group``, ``$sort``, ...).
+        """
+        return self.fetch(pipeline=pipeline, batch_size=batch_size, timeout=timeout).to_pandas()
+
+    def _read_with_retry(
+        self, pipeline: bytes, batch_size: int | None, timeout: float | None
+    ) -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+        """Stream chunks, re-resolving the collection once on a stale UUID.
+
+        A cached slug->UUID mapping can go stale (the collection was recreated
+        or its slug remapped); the first read then fails ``NOT_FOUND``. When
+        the id came from a slug, drop the cache entry and resolve again before
+        surfacing the error. A UUID passed directly is not retried — there is
+        nothing to re-resolve.
+        """
+
+        def _open() -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+            return self._stream(
+                collection=self.collection_id,
+                pipeline=pipeline,
+                query=None,
+                batch_size=batch_size,
+                timeout=timeout,
+            )
+
+        def _on_stale() -> None:
+            self._client._resolver.invalidate_collection(self._ref, self._location)
+            self._id = None
+
+        return self._read_reresolving(_open, _on_stale)
+
+    # -- writes ----------------------------------------------------------
+
+    def append(
+        self,
+        df: pd.DataFrame,
+        *,
+        chunk_rows: int = _codec.DEFAULT_CHUNK_ROWS,
+        progress: ProgressCallback | None = None,
+        timeout: float | None = None,
+    ) -> int:
+        """Insert every row of ``df`` as new documents. Returns rows written.
+
+        Uploads stream in chunks of ``chunk_rows`` (a failed chunk is
+        retryable at the flow level, not a whole-frame resend). ``progress`` is
+        invoked with the cumulative row count after each chunk — handy for a
+        notebook progress bar.
+        """
+        insert_pb2 = _import("clappform.gen.clappform.data.v1.insert.insert_pb2")
+        records = _records_from_frame(df)
+
+        def _requests() -> Iterator[Any]:
+            written = 0
+            for chunk in _codec.chunk_records(records, chunk_rows):
+                yield insert_pb2.InsertRequest(collection=self.collection_id, data=chunk)
+                written += _rows_in(chunk)
+                if progress is not None:
+                    progress(written)
+
+        total = 0
+        for response in self._client.data.insert.insert_many(
+            _requests(), location=self._location, timeout=timeout
+        ):
+            total += response.processed_count
+        return total
+
+    def update(
+        self,
+        df: pd.DataFrame,
+        *,
+        on: str = "_id",
+        chunk_rows: int = _codec.DEFAULT_CHUNK_ROWS,
+        timeout: float | None = None,
+    ) -> int:
+        """Update existing documents, matched by the ``on`` column (default ``_id``).
+
+        Every row must carry the ``on`` key. Because ``read()`` keeps ``_id`` as
+        a column, the common case — read, mutate other columns, ``update(df)`` —
+        needs no argument at all.
+        """
+        update_pb2 = _import("clappform.gen.clappform.data.v1.update.update_pb2")
+        records = _records_from_frame(df)
+        _require_key(records, on, "update")
+
+        def _requests() -> Iterator[Any]:
+            for chunk in _codec.chunk_records(records, chunk_rows):
+                yield update_pb2.UpdateRequestByOid(collection=self.collection_id, data=chunk)
+
+        self._client.data.update.update_many(_requests(), location=self._location, timeout=timeout)
+        return len(records)
+
+    def upsert(
+        self,
+        df: pd.DataFrame,
+        *,
+        on: str,
+        chunk_rows: int = _codec.DEFAULT_CHUNK_ROWS,
+        timeout: float | None = None,
+    ) -> int:
+        """Insert-or-update every row keyed on the business column ``on``.
+
+        Uses ``SyncManyByField``: rows whose ``on`` value already exists are
+        updated, the rest inserted. ``on`` is required — an upsert has no
+        default key the way :meth:`update` does.
+        """
+        sync_pb2 = _import("clappform.gen.clappform.data.v1.sync.sync_pb2")
+        records = _records_from_frame(df)
+        _require_key(records, on, "upsert")
+
+        def _requests() -> Iterator[Any]:
+            for chunk in _codec.chunk_records(records, chunk_rows):
+                yield sync_pb2.SyncRequestByField(
+                    collection=self.collection_id, data=chunk, field_name=on
+                )
+
+        self._client.data.sync.sync_many_by_field(
+            _requests(), location=self._location, timeout=timeout
+        )
+        return len(records)
+
+    def replace_where(
+        self,
+        where: Mapping[str, Any],
+        set_values: Mapping[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        """Set ``set_values`` on every document matching the ``where`` filter.
+
+        A single server-side ``$set`` over the matched documents
+        (``UpdateManyByQuery``) — no data is round-tripped through the client.
+        """
+        self._client.data.update.update_many_by_query(
+            collection=self.collection_id,
+            query=_codec.encode_pipeline(dict(where)),
+            set_values=_codec.encode_pipeline(dict(set_values)),
+            location=self._location,
+            timeout=timeout,
+        )
+
+    def delete(
+        self,
+        *,
+        where: Mapping[str, Any] | None = None,
+        oids: Sequence[str] | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        """Delete documents by ``where`` filter or by explicit ``oids``.
+
+        Exactly one of ``where`` / ``oids`` must be given. To wipe the whole
+        collection use :meth:`clear`, which is explicit by design so a full
+        delete is never an accident of an empty filter.
+        """
+        if (where is None) == (oids is None):
+            raise ValueError("pass exactly one of where= or oids=")
+        if oids is not None:
+            self._client.data.delete.delete_many_by_oids(
+                collection=self.collection_id,
+                oids=list(oids),
+                location=self._location,
+                timeout=timeout,
+            )
+            return
+        assert where is not None  # guaranteed by the XOR check above
+        self._client.data.delete.delete_many_by_query(
+            collection=self.collection_id,
+            query=_codec.encode_pipeline(dict(where)),
+            location=self._location,
+            timeout=timeout,
+        )
+
+    def clear(self, *, timeout: float | None = None) -> None:
+        """Remove every document from the collection (an explicit full wipe)."""
+        self._client.data.delete.clear(
+            collection=self.collection_id, location=self._location, timeout=timeout
+        )
+
+
+class QueryHandle(_AggregateReader):
+    """A handle to a saved server-side query: read-only aggregation.
+
+    Obtained from ``cf.data.query(ref)`` where ``ref`` is the query's name or
+    UUID. A saved query already carries its own collection and pipeline, so the
+    handle sends only the ``query`` field on ``AggregateStream`` — no
+    collection, no pipeline, and no write surface.
+    """
+
+    __slots__ = ("_client", "_ref", "_location", "_id")
+
+    def __init__(self, client: Clappform, ref: str) -> None:
+        self._client = client
+        self._ref = ref
+        self._location = client.location
+        self._id: str | None = None
+
+    @property
+    def query_id(self) -> str:
+        """The resolved saved-query UUID (resolves + caches on first access)."""
+        if self._id is None:
+            self._id = self._client._resolver.query_id(self._ref, self._location)
+        return self._id
+
+    def __repr__(self) -> str:
+        resolved = f" -> {self._id}" if self._id is not None else ""
+        return f"QueryHandle({self._ref!r}{resolved}, location={self._location!r})"
+
+    def fetch(self, *, batch_size: int | None = None, timeout: float | None = None) -> ReadResult:
+        """Run the saved query and stream its result into a :class:`ReadResult`."""
+        return ReadResult(self._read_with_retry(batch_size, timeout))
+
+    def read(self, *, batch_size: int | None = None, timeout: float | None = None) -> pd.DataFrame:
+        """Run the saved query and return its result as a pandas DataFrame."""
+        return self.fetch(batch_size=batch_size, timeout=timeout).to_pandas()
+
+    def iter_batches(
+        self, *, batch_size: int | None = None, timeout: float | None = None
+    ) -> Iterator[list[Record]]:
+        """Stream the saved query's result in memory-bounded batches."""
+        return self.fetch(batch_size=batch_size, timeout=timeout).iter_batches()
+
+    def _read_with_retry(
+        self, batch_size: int | None, timeout: float | None
+    ) -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+        """Stream chunks, re-resolving the query once on a stale UUID."""
+
+        def _open() -> Iterator[tuple[_codec.ChunkFormat, bytes]]:
+            return self._stream(
+                collection=None,
+                pipeline=None,
+                query=self.query_id,
+                batch_size=batch_size,
+                timeout=timeout,
+            )
+
+        def _on_stale() -> None:
+            self._client._resolver.invalidate_query(self._ref, self._location)
+            self._id = None
+
+        return self._read_reresolving(_open, _on_stale)
+
+
+# -- small helpers -------------------------------------------------------
+
+
+def _import(module: str) -> Any:
+    """Import a generated pb2 module by dotted path (kept lazy and local)."""
+    import importlib
+
+    return importlib.import_module(module)
+
+
+def _rows_in(chunk: bytes) -> int:
+    """Count the records a JSON chunk carries (for progress reporting)."""
+    return len(_codec.bytes_to_records(chunk))
+
+
+def _require_key(records: list[Record], key: str, op: str) -> None:
+    """Fail fast if any record lacks the join key an update/upsert needs."""
+    for record in records:
+        if key not in record:
+            raise ValueError(f"{op} keyed on {key!r} but a row is missing that column")

--- a/src/clappform/testing/_local_mock.py
+++ b/src/clappform/testing/_local_mock.py
@@ -10,13 +10,22 @@ It offers two layers:
   handler callable, or (for streaming RPCs) an iterable of responses, keyed by
   the full gRPC method path. This works for *any* RPC in the client.
 * **A seedable data-plane store** — :meth:`LocalMock.seed` loads records into a
-  named collection, and built-in handlers for the core data RPCs
-  (``AggregateStream``, ``InsertSingle``/``InsertMany``, ``UpdateMany`` by
-  ``_id``, the delete RPCs and ``Clear``) read and mutate that store through the
-  same JSON codec the real client uses. That is what lets a
-  read -> mutate -> update round-trip run end-to-end in tests and in
-  ``examples/``. An explicit stub for a method always wins over the built-in
-  handler.
+  named collection, and built-in handlers for the core data RPCs read and
+  mutate that store through the same JSON codec the real client uses:
+
+  - ``AggregateStream`` (honours the ``$match``/``$project``/``$limit`` stages
+    the DataFrame sugar compiles, and resolves a saved ``query`` through
+    :meth:`seed_query`),
+  - ``InsertSingle``/``InsertMany``, ``UpdateMany`` by ``_id``,
+  - ``SyncManyByField`` (upsert on a business key),
+  - ``UpdateManyByQuery`` (``replace_where``) and ``DeleteManyByQuery``,
+  - ``DeleteManyByOids`` and ``Clear``.
+
+  That is what lets the full DataFrame surface — read, filter, mutate, update,
+  upsert, replace-where, delete — round-trip end-to-end in tests and in
+  ``examples/``. :meth:`seed_collection_slug` and :meth:`seed_query` register
+  the Client API listings so slug/name resolution also runs without a server.
+  An explicit stub for a method always wins over the built-in handler.
 
 Every call is recorded on :attr:`LocalMock.calls` for assertions.
 """
@@ -24,6 +33,7 @@ Every call is recorded on :attr:`LocalMock.calls` for assertions.
 from __future__ import annotations
 
 import itertools
+import json
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -56,6 +66,9 @@ class LocalMock:
         self.calls: list[RecordedCall] = []
         self._stubs: dict[str, Any] = {}
         self._store: dict[str, list[_codec.Record]] = {}
+        self._queries: dict[str, str] = {}  # saved-query id -> backing collection
+        self._query_listing: dict[str, str] = {}  # query name -> id (for GetAll)
+        self._collection_listing: dict[str, str] = {}  # collection slug -> id
         self._oids = itertools.count(1)
         self._closed = False
 
@@ -88,6 +101,67 @@ class LocalMock:
         self._store[collection] = stored
         return self
 
+    def seed_query(self, ref: str, *, collection: str, id: str | None = None) -> LocalMock:
+        """Register a saved query ``ref`` that reads from ``collection``.
+
+        Lets ``cf.data.query(ref).read()`` work end-to-end: a name ``ref``
+        resolves through a canned ``QueryManagement/GetAll`` (so the client's
+        name->UUID lookup finds it), and the AggregateStream handler serves the
+        backing ``collection``'s rows for the resulting query id. A ``ref`` that
+        is already a UUID skips resolution and is used as the id directly.
+        ``id`` overrides the generated UUID. Returns ``self`` for chaining.
+        """
+        from clappform._resolve import is_uuid
+
+        query_id = id or (ref if is_uuid(ref) else self._next_oid())
+        self._queries[query_id] = collection
+        if not is_uuid(ref):
+            self._register_query_listing(ref, query_id)
+        return self
+
+    def _register_query_listing(self, name: str, query_id: str) -> None:
+        """Add ``name``->``query_id`` to the canned query GetAll listing."""
+        from clappform.gen.clappform.client.v1.query import query_pb2
+        from clappform.gen.clappform.v1.commons import commons_pb2
+
+        self._query_listing[name] = query_id
+
+        def _get_all(_request: Any) -> Any:
+            queries = [
+                query_pb2.Query(id=qid, name=qname) for qname, qid in self._query_listing.items()
+            ]
+            return query_pb2.Queries(
+                queries=queries,
+                pagination=commons_pb2.Pagination(page=1, pages=1, total=len(queries)),
+            )
+
+        self.on("/clappform.client.v1.query.QueryManagement/GetAll", _get_all)
+
+    def seed_collection_slug(self, slug: str, *, id: str) -> LocalMock:
+        """Register a collection ``slug``->``id`` mapping for slug resolution.
+
+        Lets ``cf.data.collection(slug).read()`` resolve the slug to ``id``
+        through a canned ``CollectionManagement/GetAll`` before reading the
+        store seeded under ``id`` (via :meth:`seed`). Returns ``self``.
+        """
+        from clappform.gen.clappform.client.v1.collection import collection_pb2
+        from clappform.gen.clappform.v1.commons import commons_pb2
+
+        self._collection_listing[slug] = id
+
+        def _get_all(_request: Any) -> Any:
+            collections = [
+                collection_pb2.Collection(id=cid, slug=cslug)
+                for cslug, cid in self._collection_listing.items()
+            ]
+            return collection_pb2.Collections(
+                collections=collections,
+                pagination=commons_pb2.Pagination(page=1, pages=1, total=len(collections)),
+            )
+
+        self.on("/clappform.client.v1.collection.CollectionManagement/GetAll", _get_all)
+        return self
+
     def records(self, collection: str) -> list[_codec.Record]:
         """A copy of the records currently stored for ``collection``."""
         return [dict(row) for row in self._store.get(collection, [])]
@@ -97,6 +171,9 @@ class LocalMock:
         self.calls.clear()
         self._stubs.clear()
         self._store.clear()
+        self._queries.clear()
+        self._query_listing.clear()
+        self._collection_listing.clear()
 
     def close(self) -> None:
         """Mark the mock closed, matching the transport's teardown contract."""
@@ -119,9 +196,7 @@ class LocalMock:
         if self._closed:
             raise ClappformError("client is closed", method=method)
         materialised = list(request) if kind.startswith("stream") else request
-        self.calls.append(
-            RecordedCall(kind, method, materialised, timeout, metadata, location)
-        )
+        self.calls.append(RecordedCall(kind, method, materialised, timeout, metadata, location))
 
         if method in self._stubs:
             return self._dispatch_stub(kind, method, materialised, response_cls)
@@ -136,9 +211,7 @@ class LocalMock:
             method=method,
         )
 
-    def _dispatch_stub(
-        self, kind: CallKind, method: str, request: Any, response_cls: type
-    ) -> Any:
+    def _dispatch_stub(self, kind: CallKind, method: str, request: Any, response_cls: type) -> Any:
         stub = self._stubs[method]
         streaming_out = kind.endswith("_stream")
         is_handler = callable(stub) and not isinstance(stub, response_cls)
@@ -165,18 +238,73 @@ class LocalMock:
     def _collection_of(self, request: Any) -> str:
         collection = getattr(request, "collection", "")
         if not collection:
+            raise ClappformError("LocalMock data handlers require a 'collection' on the request")
+        return collection
+
+
+def _aggregate_target(mock: LocalMock, request: Any) -> str:
+    """The collection an AggregateStream request reads from.
+
+    A ``query`` request names a saved query, which resolves to its backing
+    collection through the ``seed_query`` registry; otherwise the request
+    carries the collection directly.
+    """
+    query = getattr(request, "query", "")
+    if query:
+        collection = mock._queries.get(query)
+        if collection is None:
             raise ClappformError(
-                "LocalMock data handlers require a 'collection' on the request"
+                f"LocalMock has no saved query {query!r}; register one with "
+                f".seed_query({query!r}, collection=...)"
             )
         return collection
+    return mock._collection_of(request)
+
+
+def _apply_pipeline(rows: list[_codec.Record], pipeline: bytes) -> list[_codec.Record]:
+    """Apply the ``$match``/``$project``/``$limit`` stages the sugar emits.
+
+    Only the stages ``read(where=, fields=, limit=)`` compiles are honoured —
+    enough to test the client sugar without reimplementing an aggregation
+    engine. ``$match`` supports equality on top-level fields; other operators
+    and stages are passed over so a caller-supplied pipeline still streams the
+    whole collection rather than erroring.
+    """
+    if not pipeline:
+        return list(rows)
+    result = list(rows)
+    for stage in json.loads(pipeline):
+        if not isinstance(stage, dict) or len(stage) != 1:
+            continue
+        ((op, arg),) = stage.items()
+        if op == "$match" and isinstance(arg, dict):
+            result = [
+                row
+                for row in result
+                if all(not isinstance(v, dict) and row.get(k) == v for k, v in arg.items())
+            ]
+        elif op == "$project" and isinstance(arg, dict):
+            keep = {k for k, v in arg.items() if v}
+            keep.add("_id")  # _id survives projection unless explicitly excluded
+            result = [{k: v for k, v in row.items() if k in keep} for row in result]
+        elif op == "$limit" and isinstance(arg, int):
+            result = result[:arg]
+    return result
 
 
 def _handle_aggregate_stream(
     mock: LocalMock, kind: CallKind, request: Any, response_cls: type
 ) -> Iterator[Any]:
-    """Serve a collection's seeded records as AggregateStream chunks."""
-    collection = mock._collection_of(request)
-    records = mock._store.get(collection, [])
+    """Serve seeded records as AggregateStream chunks.
+
+    Resolves the target collection from either the ``collection`` field or a
+    saved ``query`` (registered via :meth:`LocalMock.seed_query`), then applies
+    the ``$match``/``$project``/``$limit`` stages the DataFrame sugar compiles,
+    so a filtered/projected/limited ``read()`` round-trips against the store.
+    Pipeline stages the sugar never emits are ignored by this double.
+    """
+    collection = _aggregate_target(mock, request)
+    records = _apply_pipeline(mock._store.get(collection, []), request.pipeline)
     total = len(records)
     batch_size = getattr(request, "batch_size", 0) or _codec.DEFAULT_CHUNK_ROWS
 
@@ -197,9 +325,7 @@ def _handle_aggregate_stream(
     return _chunks()
 
 
-def _handle_insert(
-    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
-) -> Any:
+def _handle_insert(mock: LocalMock, kind: CallKind, request: Any, response_cls: type) -> Any:
     """Append decoded records to the store, assigning ids; report counts.
 
     Handles ``InsertSingle`` (unary-unary) and ``InsertMany`` (stream-stream).
@@ -238,9 +364,7 @@ def _build_response(response_cls: type, **fields: Any) -> Any:
     return response_cls(**kept)
 
 
-def _handle_update_many(
-    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
-) -> Any:
+def _handle_update_many(mock: LocalMock, kind: CallKind, request: Any, response_cls: type) -> Any:
     """Apply field updates to stored rows matched by ``_id``.
 
     ``UpdateMany`` is stream-unary, so ``request`` is a list of update messages;
@@ -265,9 +389,7 @@ def _handle_update_many(
     )
 
 
-def _handle_delete_oids(
-    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
-) -> Any:
+def _handle_delete_oids(mock: LocalMock, kind: CallKind, request: Any, response_cls: type) -> Any:
     """Remove stored rows whose ``_id`` is in the request's oids."""
     collection = mock._collection_of(request)
     store = mock._store.setdefault(collection, [])
@@ -283,9 +405,89 @@ def _handle_delete_oids(
     )
 
 
-def _handle_clear(
+def _handle_sync_by_field(
     mock: LocalMock, kind: CallKind, request: Any, response_cls: type
 ) -> Any:
+    """Upsert rows keyed on ``field_name``: update matches, insert the rest.
+
+    ``SyncManyByField`` is stream-unary, so ``request`` is a list of sync
+    messages; each message's records are matched against the store by their
+    ``field_name`` value.
+    """
+    requests = request if isinstance(request, list) else [request]
+    collection = ""
+    for req in requests:
+        collection = mock._collection_of(req)
+        field = req.field_name
+        store = mock._store.setdefault(collection, [])
+        by_key = {row.get(field): row for row in store}
+        for record in _codec.bytes_to_records(req.data):
+            key = record.get(field)
+            target = by_key.get(key)
+            if target is not None:
+                target.update(record)
+            else:
+                row = dict(record)
+                if "_id" not in row or row["_id"] is None:
+                    row["_id"] = mock._next_oid()
+                store.append(row)
+                by_key[key] = row
+    store = mock._store.get(collection, [])
+    return _build_response(
+        response_cls,
+        data=_codec.records_to_bytes(store),
+        collection=collection,
+        message=f"synced {collection!r}",
+    )
+
+
+def _handle_update_by_query(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Apply ``set_values`` to every stored row matching the query filter.
+
+    Backs ``replace_where``. The query and set-values are JSON as the client
+    sends them; only equality on top-level fields is matched, matching the
+    aggregate handler's ``$match`` support.
+    """
+    collection = mock._collection_of(request)
+    store = mock._store.setdefault(collection, [])
+    query = json.loads(request.query) if request.query else {}
+    set_values = json.loads(request.set_values) if request.set_values else {}
+    matched = 0
+    for row in store:
+        if all(row.get(k) == v for k, v in query.items()):
+            row.update(set_values)
+            matched += 1
+    return _build_response(
+        response_cls,
+        data=_codec.records_to_bytes(store),
+        collection=collection,
+        total=len(store),
+        total_sent=matched,
+        message=f"updated {matched} rows in {collection!r}",
+    )
+
+
+def _handle_delete_by_query(
+    mock: LocalMock, kind: CallKind, request: Any, response_cls: type
+) -> Any:
+    """Remove stored rows matching the query filter (equality on top-level)."""
+    collection = mock._collection_of(request)
+    store = mock._store.setdefault(collection, [])
+    query = json.loads(request.query) if request.query else {}
+    kept = [row for row in store if not all(row.get(k) == v for k, v in query.items())]
+    removed = len(store) - len(kept)
+    mock._store[collection] = kept
+    return _build_response(
+        response_cls,
+        total=len(kept),
+        total_sent=removed,
+        message=f"deleted {removed} rows",
+    )
+
+
+def _handle_clear(mock: LocalMock, kind: CallKind, request: Any, response_cls: type) -> Any:
     """Empty a collection's store."""
     collection = mock._collection_of(request)
     mock._store[collection] = []
@@ -293,13 +495,14 @@ def _handle_clear(
 
 
 # Full method path -> built-in data-plane handler. Explicit .on() stubs win.
-_DATA_HANDLERS: dict[
-    str, Callable[[LocalMock, CallKind, Any, type], Any]
-] = {
+_DATA_HANDLERS: dict[str, Callable[[LocalMock, CallKind, Any, type], Any]] = {
     "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream": _handle_aggregate_stream,
     "/clappform.data.v1.insert.InsertManagement/InsertSingle": _handle_insert,
     "/clappform.data.v1.insert.InsertManagement/InsertMany": _handle_insert,
     "/clappform.data.v1.update.UpdateManagement/UpdateMany": _handle_update_many,
+    "/clappform.data.v1.update.UpdateManagement/UpdateManyByQuery": _handle_update_by_query,
+    "/clappform.data.v1.sync.SyncManagement/SyncManyByField": _handle_sync_by_field,
     "/clappform.data.v1.delete.DeleteManagement/DeleteManyByOids": _handle_delete_oids,
+    "/clappform.data.v1.delete.DeleteManagement/DeleteManyByQuery": _handle_delete_by_query,
     "/clappform.data.v1.delete.DeleteManagement/Clear": _handle_clear,
 }

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -1,0 +1,294 @@
+"""Collection/query handles and ReadResult — the DataFrame surface.
+
+Drives the flows through the real ``Clappform`` client against ``LocalMock``,
+exactly as customers and ``examples/`` do: seed a collection, read it into a
+frame, mutate, and write back, asserting the store reflects each flow.
+"""
+
+import pandas as pd
+import pytest
+
+from clappform import Clappform, ClappformError, ReadResult
+from clappform.dataframes import CollectionHandle, QueryHandle
+from clappform.testing import LocalMock
+
+CID = "1c9a7f3e-0000-4000-8000-000000000001"
+
+
+@pytest.fixture
+def cf():
+    mock = LocalMock()
+    client = Clappform("acme", "qa", api_key="k", transport=mock)
+    yield client, mock
+    client.close()
+
+
+def _seed_orders(mock):
+    mock.seed(
+        CID,
+        [
+            {"order_id": 1, "status": "open", "amount": 10.0},
+            {"order_id": 2, "status": "closed", "amount": 20.0},
+            {"order_id": 3, "status": "open", "amount": 30.0},
+        ],
+    )
+
+
+# -- reads ---------------------------------------------------------------
+
+
+def test_read_returns_whole_collection_as_frame(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    df = client.data.collection(CID).read()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 3
+    assert "_id" in df.columns  # kept for round-trip updates
+
+
+def test_read_where_filters_rows(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    df = client.data.collection(CID).read(where={"status": "open"})
+    assert sorted(df["order_id"]) == [1, 3]
+
+
+def test_read_fields_projects_columns_but_keeps_id(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    df = client.data.collection(CID).read(fields=["order_id", "amount"])
+    assert set(df.columns) == {"order_id", "amount", "_id"}
+
+
+def test_read_limit_caps_rows(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    df = client.data.collection(CID).read(limit=2)
+    assert len(df) == 2
+
+
+def test_read_equals_fetch_to_pandas(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    col = client.data.collection(CID)
+    from_read = col.read(where={"status": "open"})
+    from_fetch = col.fetch(where={"status": "open"}).to_pandas()
+    pd.testing.assert_frame_equal(from_read, from_fetch)
+
+
+def test_fetch_returns_readresult(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    result = client.data.collection(CID).fetch()
+    assert isinstance(result, ReadResult)
+    assert len(list(result)) == 3
+
+
+def test_readresult_is_single_pass(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    result = client.data.collection(CID).fetch()
+    list(result)
+    with pytest.raises(ClappformError, match="already been consumed"):
+        list(result)
+
+
+def test_iter_batches_yields_one_list_per_chunk(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    batches = list(client.data.collection(CID).iter_batches(batch_size=2))
+    assert [len(b) for b in batches] == [2, 1]
+
+
+def test_empty_collection_reads_empty_frame(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [])
+    df = client.data.collection(CID).read()
+    assert df.empty
+
+
+def test_fetch_rejects_pipeline_with_sugar(cf) -> None:
+    client, _mock = cf
+    with pytest.raises(ValueError, match="not both"):
+        client.data.collection(CID).fetch(pipeline=[{"$match": {}}], where={"x": 1})
+
+
+def test_negative_limit_rejected(cf) -> None:
+    client, _mock = cf
+    with pytest.raises(ValueError, match="non-negative"):
+        client.data.collection(CID).read(limit=-1)
+
+
+def test_aggregate_passes_pipeline_through(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    # A $match stage the sugar could also emit — proves the custom path streams.
+    df = client.data.collection(CID).aggregate([{"$match": {"status": "closed"}}])
+    assert list(df["order_id"]) == [2]
+
+
+# -- writes --------------------------------------------------------------
+
+
+def test_append_inserts_rows_and_returns_count(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [])
+    n = client.data.collection(CID).append(
+        pd.DataFrame([{"order_id": 10}, {"order_id": 11}])
+    )
+    assert n == 2
+    assert len(mock.records(CID)) == 2
+
+
+def test_append_reports_progress_per_chunk(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [])
+    seen: list[int] = []
+    client.data.collection(CID).append(
+        pd.DataFrame([{"n": i} for i in range(5)]),
+        chunk_rows=2,
+        progress=seen.append,
+    )
+    assert seen == [2, 4, 5]  # cumulative row count after each chunk
+
+
+def test_append_empty_frame_writes_nothing(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [])
+    n = client.data.collection(CID).append(pd.DataFrame())
+    assert n == 0
+    assert mock.records(CID) == []
+
+
+def test_read_mutate_update_round_trip(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    col = client.data.collection(CID)
+    df = col.read()
+    df.loc[df["order_id"] == 1, "status"] = "archived"
+    updated = col.update(df)  # defaults to on="_id", kept by read()
+    assert updated == 3
+    by_id = {r["order_id"]: r["status"] for r in mock.records(CID)}
+    assert by_id[1] == "archived" and by_id[2] == "closed"
+
+
+def test_update_missing_key_raises(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    with pytest.raises(ValueError, match="missing that column"):
+        client.data.collection(CID).update(pd.DataFrame([{"status": "x"}]), on="_id")
+
+
+def test_upsert_updates_existing_and_inserts_new(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    n = client.data.collection(CID).upsert(
+        pd.DataFrame(
+            [{"order_id": 2, "status": "reopened"}, {"order_id": 99, "status": "new"}]
+        ),
+        on="order_id",
+    )
+    assert n == 2
+    by_id = {r["order_id"]: r["status"] for r in mock.records(CID)}
+    assert by_id[2] == "reopened"
+    assert by_id[99] == "new"
+    assert len(mock.records(CID)) == 4
+
+
+def test_replace_where_sets_values_on_matches(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    client.data.collection(CID).replace_where({"status": "open"}, {"status": "seen"})
+    statuses = sorted(r["status"] for r in mock.records(CID))
+    assert statuses == ["closed", "seen", "seen"]
+
+
+def test_delete_by_where_removes_matches(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    client.data.collection(CID).delete(where={"status": "open"})
+    assert [r["order_id"] for r in mock.records(CID)] == [2]
+
+
+def test_delete_by_oids_removes_those_rows(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"_id": "a"}, {"_id": "b"}, {"_id": "c"}])
+    client.data.collection(CID).delete(oids=["a", "c"])
+    assert [r["_id"] for r in mock.records(CID)] == ["b"]
+
+
+def test_delete_requires_exactly_one_selector(cf) -> None:
+    client, _mock = cf
+    col = client.data.collection(CID)
+    with pytest.raises(ValueError, match="exactly one"):
+        col.delete()
+    with pytest.raises(ValueError, match="exactly one"):
+        col.delete(where={"x": 1}, oids=["a"])
+
+
+def test_clear_empties_collection(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    client.data.collection(CID).clear()
+    assert mock.records(CID) == []
+
+
+# -- pandas optional-dependency seam -------------------------------------
+
+
+def test_to_pandas_without_pandas_raises_install_hint(cf, monkeypatch) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    result = client.data.collection(CID).fetch()
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_pandas(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError("no pandas")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_pandas)
+    with pytest.raises(ClappformError, match=r"pip install clappform\[pandas\]"):
+        result.to_pandas()
+
+
+# -- pipeline compilation -------------------------------------------------
+
+
+def test_compiled_pipeline_matches_manual_aggregate(cf) -> None:
+    """read(where/fields/limit) must send the same pipeline aggregate() would."""
+    client, mock = cf
+    _seed_orders(mock)
+    col = client.data.collection(CID)
+
+    col.read(where={"status": "open"}, fields=["order_id"], limit=1)
+    sugar_pipeline = _last_pipeline(mock)
+
+    col.aggregate(
+        [
+            {"$match": {"status": "open"}},
+            {"$project": {"order_id": 1}},
+            {"$limit": 1},
+        ]
+    )
+    manual_pipeline = _last_pipeline(mock)
+    assert sugar_pipeline == manual_pipeline
+
+
+def _last_pipeline(mock: LocalMock):
+    import json
+
+    for call in reversed(mock.calls):
+        if call.method.endswith("/AggregateStream"):
+            return json.loads(call.request.pipeline)
+    raise AssertionError("no AggregateStream call recorded")
+
+
+def test_collection_handle_repr(cf) -> None:
+    client, _mock = cf
+    assert "CollectionHandle" in repr(client.data.collection(CID))
+    assert isinstance(client.data.collection(CID), CollectionHandle)
+    assert isinstance(client.data.query(CID), QueryHandle)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,212 @@
+"""Slug/name -> UUID resolution for collection and query handles (issue #42).
+
+Exercises the resolver through the real client and ``LocalMock``: UUIDs pass
+through untouched, slugs resolve via the Client API and cache per location, a
+stale cached UUID re-resolves once, and an unknown slug raises ``NotFoundError``.
+"""
+
+import pytest
+
+from clappform import Clappform, NotFoundError
+from clappform._resolve import is_uuid
+from clappform.testing import LocalMock
+
+CID = "1c9a7f3e-0000-4000-8000-000000000001"
+QID = "8f14e45f-ceea-467f-a34e-95b7f7f7a9d1"
+COLLECTION_GET_ALL = "/clappform.client.v1.collection.CollectionManagement/GetAll"
+AGG = "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream"
+
+
+@pytest.fixture
+def cf():
+    mock = LocalMock()
+    client = Clappform("acme", "qa", api_key="k", transport=mock)
+    yield client, mock
+    client.close()
+
+
+# -- UUID detection ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (CID, True),
+        ("{1c9a7f3e-0000-4000-8000-000000000001}", True),
+        ("sales_orders", False),
+        ("monthly-revenue", False),  # a hyphenated slug is NOT a uuid
+        ("", False),
+    ],
+)
+def test_is_uuid(value, expected) -> None:
+    assert is_uuid(value) is expected
+
+
+# -- collection resolution -----------------------------------------------
+
+
+def test_uuid_ref_is_used_without_lookup(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"n": 1}])
+    df = client.data.collection(CID).read()
+    assert len(df) == 1
+    # No collection listing was consulted — the UUID went straight through.
+    assert not any(c.method == COLLECTION_GET_ALL for c in mock.calls)
+
+
+def test_slug_resolves_and_reads(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"n": 1}, {"n": 2}])
+    mock.seed_collection_slug("sales_orders", id=CID)
+    col = client.data.collection("sales_orders")
+    assert len(col.read()) == 2
+    assert col.collection_id == CID
+
+
+def test_slug_resolution_is_cached_across_calls(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"n": 1}])
+    mock.seed_collection_slug("sales_orders", id=CID)
+    col = client.data.collection("sales_orders")
+    col.read()
+    col.read()
+    col.read()
+    lookups = [c for c in mock.calls if c.method == COLLECTION_GET_ALL]
+    assert len(lookups) == 1  # one extra RPC per process, not per call
+
+
+def test_unknown_slug_raises_not_found_naming_slug_and_location(cf) -> None:
+    client, mock = cf
+    mock.seed_collection_slug("exists", id=CID)  # registers the listing, not our slug
+    with pytest.raises(NotFoundError, match="ghost") as exc:
+        client.data.collection("ghost").read()
+    assert "acme" in str(exc.value)  # the location searched
+
+
+def test_stale_cached_uuid_reresolves_once(cf) -> None:
+    """A cached slug->UUID that NOT_FOUNDs must re-resolve before surfacing."""
+    client, mock = cf
+    old_id, new_id = CID, "2222aaaa-0000-4000-8000-000000000002"
+    mock.seed(new_id, [{"n": 42}])
+    mock.seed_collection_slug("sales_orders", id=old_id)
+
+    # First read resolves "sales_orders" -> old_id and caches it, but old_id
+    # has no store and (per this stub) reads NOT_FOUND. Re-point the slug at the
+    # live collection so the re-resolution finds it.
+
+    def _agg(request):
+        if request.collection == old_id:
+            raise NotFoundError("collection gone", location="acme")
+        # serve new_id's rows as a single chunk
+        from clappform import _codec
+        from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+
+        rows = mock.records(new_id)
+        return [aggregate_pb2.AggregateResponse(data=_codec.records_to_bytes(rows))]
+
+    mock.on(AGG, _agg)
+
+    col = client.data.collection("sales_orders")
+    assert col.collection_id == old_id  # resolves + caches old_id
+    mock.seed_collection_slug("sales_orders", id=new_id)  # slug remapped
+
+    df = col.read()  # first attempt hits old_id -> NOT_FOUND -> re-resolve
+    assert list(df["n"]) == [42]
+    assert col.collection_id == new_id
+
+
+def test_not_found_after_first_chunk_is_not_retried(cf) -> None:
+    """A NOT_FOUND once rows have streamed surfaces raw — no silent replay.
+
+    Re-resolving mid-stream would re-deliver already-yielded rows, so the retry
+    is intentionally limited to a NOT_FOUND on the probing first chunk.
+    """
+    client, mock = cf
+    from clappform import _codec
+    from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+
+    mock.seed_collection_slug("orders", id=CID)
+
+    def _agg(_request):
+        def _stream():
+            yield aggregate_pb2.AggregateResponse(
+                data=_codec.records_to_bytes([{"n": 1}])
+            )
+            raise NotFoundError("collection vanished mid-scan", location="acme")
+
+        return _stream()
+
+    mock.on(AGG, _agg)
+    with pytest.raises(NotFoundError, match="mid-scan"):
+        client.data.collection("orders").read()
+
+
+def test_reads_isolate_cache_per_location(cf) -> None:
+    """A slug resolved for one tenant is not reused for another (per-location)."""
+    client, mock = cf
+    other = client.with_location("umbrella")
+    a_id, b_id = CID, "3333bbbb-0000-4000-8000-000000000003"
+    mock.seed(a_id, [{"who": "acme"}])
+    mock.seed(b_id, [{"who": "umbrella"}])
+
+    def _get_all(request):
+        from clappform.gen.clappform.client.v1.collection import collection_pb2
+        from clappform.gen.clappform.v1.commons import commons_pb2
+
+        # the listing depends on which tenant asks (location metadata)
+        loc = _location_of(mock)
+        cid = a_id if loc == "acme" else b_id
+        return collection_pb2.Collections(
+            collections=[collection_pb2.Collection(id=cid, slug="orders")],
+            pagination=commons_pb2.Pagination(page=1, pages=1, total=1),
+        )
+
+    mock.on(COLLECTION_GET_ALL, _get_all)
+
+    assert client.data.collection("orders").collection_id == a_id
+    assert other.data.collection("orders").collection_id == b_id
+
+
+def _location_of(mock: LocalMock) -> str:
+    for call in reversed(mock.calls):
+        if call.method == COLLECTION_GET_ALL:
+            return call.location
+    raise AssertionError("no listing call recorded")
+
+
+# -- saved-query resolution ----------------------------------------------
+
+
+def test_query_by_uuid_reads_without_lookup(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"r": 1}, {"r": 2}])
+    mock.seed_query(QID, collection=CID, id=QID)
+    df = client.data.query(QID).read()
+    assert len(df) == 2
+
+
+def test_query_by_name_resolves_and_reads(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"revenue": 100}])
+    mock.seed_query("monthly-revenue", collection=CID, id=QID)
+    q = client.data.query("monthly-revenue")
+    df = q.read()
+    assert list(df["revenue"]) == [100]
+    assert q.query_id == QID
+
+
+def test_query_sends_only_query_field_no_collection(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"r": 1}])
+    mock.seed_query("monthly-revenue", collection=CID, id=QID)
+    client.data.query("monthly-revenue").read()
+    (agg_call,) = [c for c in mock.calls if c.method == AGG]
+    assert agg_call.request.query == QID
+    assert not agg_call.request.collection  # a saved query carries its own
+
+
+def test_unknown_query_name_raises(cf) -> None:
+    client, mock = cf
+    mock.seed_query("exists", collection=CID, id=QID)
+    with pytest.raises(NotFoundError, match="phantom"):
+        client.data.query("phantom").read()


### PR DESCRIPTION
## Summary

- Add the DataFrame surface reached via `cf.data.collection(ref)` / `cf.data.query(ref)`: `CollectionHandle` (read/fetch/iter_batches with `where`/`fields`/`limit` sugar, `aggregate()` for caller pipelines, and append/update/upsert/replace_where/delete/clear write flows), `QueryHandle` (read-only over a saved query), and `ReadResult` as the single-pass seam `read()` converts via `to_pandas()`.
- Add slug/name → UUID resolution for collections and saved queries: UUID-shaped refs pass through untouched; slugs/names resolve through the Client API once and cache per location on the client, re-resolving once if a cached UUID later returns `NOT_FOUND`.
- Generalize the pipeline encoding to JSON for all backends (`encode_pipeline`); the server converts to BSON for Mongo-backed collections itself.
- Extend `LocalMock` so the full read → mutate → write round-trip and slug/name resolution run without a server, and add tests covering both tickets.

## Related issues

- Closes #41 — v6: Collection handle + ReadResult — DataFrame flows
- Closes #42 — v6: saved-query handle + slug->UUID resolution

## Tests

- `tests/test_dataframes.py` — read/fetch/iter_batches, the `where`/`fields`/`limit` sugar, read→mutate→update round-trip, chunked append with progress, upsert, replace_where, delete (filter + oids), clear, the single-pass `ReadResult` guard, the pandas install-hint seam, and pipeline-equivalence between the sugar and `aggregate()`.
- `tests/test_resolve.py` — UUID pass-through, slug resolution with per-process caching, per-location cache isolation, stale-UUID re-resolution (and that a mid-stream `NOT_FOUND` is not retried), and `NotFoundError` for unknown slugs/names.
- `python -m ruff check .`, `python -m mypy src/clappform tools`, `python -m pytest -q` (152 passed) all green locally.

## Notes

- Design of record: `DESIGN.md` §6 (DataFrame integration), §6.1 (slug-or-UUID resolution), §6.2 (`ReadResult`).
- The DataFrame entry points are attached to the generated `cf.data` sub-client at bind time rather than baked into codegen, since `services/data.py` is generated and not hand-edited.
- Pipeline bytes go across as JSON for both Mongo- and Elastic-backed collections (server reads the map and converts to BSON for Mongo); no client-side BSON dependency is introduced.
- The stale-UUID retry deliberately covers only a `NOT_FOUND` raised before any row reaches the caller; once rows have streamed, retrying would replay them, so a later `NOT_FOUND` surfaces unchanged.
- Follow-up: the arrow/polars surfaces on `ReadResult` (§11) remain deferred; the seam is in place.
- Base branch is `Major/6` (integration), not the default branch, so the linked issues are closed manually when this merges.