### PR TITLE
Test coverage gate + pandas NA codec fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e .[dev,pandas]
-      - run: python -m pytest -q
+      # --cov enforces the fail_under gate in [tool.coverage.report] on every
+      # PR (pull_request above has no branch filter, so this runs on all PRs).
+      - run: python -m pytest -q --cov --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: python -m pip install -e .[dev]
       - run: python -m ruff check .
 
@@ -23,6 +25,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: python -m pip install -e .[dev,pandas]
       - run: python -m mypy src/clappform tools
 
@@ -38,6 +42,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Cache pip's downloads and built wheels. Versions without prebuilt
+          # wheels for a dependency (currently 3.14 for grpcio/pandas/pyarrow)
+          # compile from source on the first run; the cache means that ~5-12min
+          # build is paid once, not on every run. Keyed on pyproject.toml, so
+          # the cache busts when dependencies change.
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: python -m pip install -e .[dev,pandas]
       # --cov enforces the fail_under gate in [tool.coverage.report] on every
       # PR (pull_request above has no branch filter, so this runs on all PRs).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ arrow = ["pyarrow>=15.0"]
 all = ["clappform[pandas,polars,arrow]"]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=5.0",
     "ruff>=0.5",
     "mypy>=1.10",
     "grpcio-tools>=1.60,<2",
@@ -83,3 +84,27 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["clappform"]
+omit = [
+    # Generated protobuf stubs and the generated service wrappers: mechanical,
+    # covered by behaviour (test_generated_services) and golden (servicegen)
+    # tests rather than per-method line coverage. Measuring them buries the
+    # hand-written surface in a misleading aggregate.
+    "src/clappform/gen/*",
+    "src/clappform/services/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+# The hand-written surface sits ~97%; hold the line and fail loudly on a
+# regression rather than letting new untested code slide in unnoticed.
+fail_under = 90
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "\\.\\.\\.$",
+]

--- a/src/clappform/_codec.py
+++ b/src/clappform/_codec.py
@@ -75,11 +75,27 @@ def _normalise_value(value: Any) -> Any:
         return {str(k): _normalise_value(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_normalise_value(v) for v in value]
-    # pandas NaT / NA and numpy NaN are floats-that-lie or singletons; catch the
-    # "not equal to itself" ones that slipped past the float branch (e.g. NaT).
-    if value != value:  # noqa: PLR0124 -- NaN/NaT sentinel check
+    # Missing-value singletons (pandas NaT/NA, numpy NaT) that slipped past the
+    # float branch compare unequal to themselves. pandas NA is doubly awkward:
+    # ``NA != NA`` returns NA, not a bool, and coercing that to bool raises
+    # "boolean value of NA is ambiguous" — so route any non-bool / raising
+    # comparison to None too, since only these missing sentinels behave that way.
+    if _is_missing_sentinel(value):
         return None
     return value
+
+
+def _is_missing_sentinel(value: Any) -> bool:
+    """True for a value that is unequal to itself (NaN/NaT/NA-style missing).
+
+    Written to survive comparison operators that do not return a plain bool
+    (pandas ``NA`` returns ``NA`` from ``!=`` and raises on truth-testing):
+    such values are themselves missing sentinels, so treat them as missing.
+    """
+    try:
+        return bool(value != value)  # noqa: PLR0124 -- NaN/NaT/NA sentinel check
+    except (TypeError, ValueError):
+        return True
 
 
 def _parse_extended_json(value: Any) -> Any:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -122,6 +122,12 @@ def test_with_location_same_location_returns_self() -> None:
     assert cf.with_location("acme") is cf
 
 
+def test_with_location_requires_a_location() -> None:
+    cf, _ = make_client()
+    with pytest.raises(ConfigurationError, match="location is required"):
+        cf.with_location("")
+
+
 def test_with_location_rediscovers_only_for_discovered_cluster(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -105,6 +105,67 @@ def test_encode_elastic_pipeline_normalises_and_serialises() -> None:
     assert json.loads(encoded) == [{"match": {"ts": "2020-01-01"}}]
 
 
+def test_non_float_nat_sentinel_becomes_null() -> None:
+    # numpy datetime64('NaT') is not a float, datetime, or container, but
+    # compares unequal to itself; it must fall through to the sentinel guard
+    # and collapse to null rather than serialising as a string.
+    import numpy as np
+
+    data = _codec.records_to_bytes([{"ts": np.datetime64("NaT"), "ok": 1}])
+    assert json.loads(data) == [{"ts": None, "ok": 1}]
+
+
+def test_nested_nat_sentinel_becomes_null() -> None:
+    # Same sentinel guard, reached through a nested container.
+    import numpy as np
+
+    data = _codec.records_to_bytes([{"items": [{"ts": np.datetime64("NaT")}]}])
+    assert json.loads(data) == [{"items": [{"ts": None}]}]
+
+
+def test_pandas_na_becomes_null_and_does_not_raise() -> None:
+    # Regression: pandas NA returns NA (not a bool) from `!= self`, and coercing
+    # that to bool raises "boolean value of NA is ambiguous". A DataFrame with a
+    # nullable dtype (convert_dtypes / Int64 / string) yields NA for missing
+    # cells, so an unguarded sentinel check crashed on encode. It must collapse
+    # to null instead.
+    import pandas as pd
+
+    data = _codec.records_to_bytes([{"amount": pd.NA, "ok": 1}])
+    assert json.loads(data) == [{"amount": None, "ok": 1}]
+
+
+def test_nested_pandas_na_becomes_null() -> None:
+    import pandas as pd
+
+    data = _codec.records_to_bytes([{"items": [{"amount": pd.NA}], "ok": 1}])
+    assert json.loads(data) == [{"items": [{"amount": None}], "ok": 1}]
+
+
+def test_pandas_nullable_dtype_frame_round_trips_missing_as_null() -> None:
+    # End-to-end: the realistic path that triggered the bug — a nullable-dtype
+    # frame with a genuinely missing cell, normalised straight from records.
+    import pandas as pd
+
+    frame = pd.DataFrame({"amount": [10, None]}).convert_dtypes()
+    data = _codec.records_to_bytes(frame.to_dict(orient="records"))
+    assert json.loads(data) == [{"amount": 10}, {"amount": None}]
+
+
+def test_extended_json_wrappers_inside_a_list_are_collapsed() -> None:
+    # _parse_extended_json must recurse into JSON arrays, not just objects.
+    payload = b'[{"ids":[{"$oid":"aa"},{"$oid":"bb"}]}]'
+    assert _codec.bytes_to_records(payload) == [{"ids": ["aa", "bb"]}]
+
+
+def test_extended_json_date_unparseable_inner_passes_through() -> None:
+    # A $date whose value is neither epoch-ms nor a string (here a bool) is not
+    # coercible and is returned structurally unchanged (the line-110 branch);
+    # a $date string, by contrast, is handled by the int()-fallback above it.
+    payload = b'[{"created":{"$date":true}}]'
+    assert _codec.bytes_to_records(payload) == [{"created": True}]
+
+
 def test_float_nan_helper_is_json_null_not_string() -> None:
     # Regression guard: NaN must not leak through as the literal "NaN" that
     # json.dumps would otherwise emit for an unguarded float.

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -14,6 +14,7 @@ from clappform.testing import LocalMock
 CID = "1c9a7f3e-0000-4000-8000-000000000001"
 QID = "8f14e45f-ceea-467f-a34e-95b7f7f7a9d1"
 COLLECTION_GET_ALL = "/clappform.client.v1.collection.CollectionManagement/GetAll"
+QUERY_GET_ALL = "/clappform.client.v1.query.QueryManagement/GetAll"
 AGG = "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream"
 
 
@@ -210,3 +211,76 @@ def test_unknown_query_name_raises(cf) -> None:
     mock.seed_query("exists", collection=CID, id=QID)
     with pytest.raises(NotFoundError, match="phantom"):
         client.data.query("phantom").read()
+
+
+def test_query_name_resolution_is_cached_across_handles(cf) -> None:
+    client, mock = cf
+    mock.seed(CID, [{"r": 1}])
+    mock.seed_query("monthly-revenue", collection=CID, id=QID)
+    # Fresh handles each round: the resolver (not the handle) must serve the
+    # second lookup from cache, so only one listing RPC hits the wire.
+    client.data.query("monthly-revenue").read()
+    client.data.query("monthly-revenue").read()
+    client.data.query("monthly-revenue").read()
+    lookups = [c for c in mock.calls if c.method == QUERY_GET_ALL]
+    assert len(lookups) == 1  # name->UUID resolved once per location, then cached
+
+
+def test_stale_cached_query_uuid_reresolves_once(cf) -> None:
+    """A cached name->UUID that NOT_FOUNDs must re-resolve before surfacing.
+
+    Mirrors the collection stale-cache path for QueryHandle: the first read
+    resolves the name to a now-defunct UUID; on the NOT_FOUND probing the first
+    chunk the handle invalidates the cache, re-resolves, and retries once.
+    """
+    client, mock = cf
+    from clappform import _codec
+    from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+
+    old_id, new_id = QID, "4444cccc-0000-4000-8000-000000000004"
+    mock.seed(CID, [{"revenue": 100}])
+    mock.seed_query("monthly-revenue", collection=CID, id=old_id)
+
+    def _agg(request):
+        if request.query == old_id:
+            raise NotFoundError("query gone", location="acme")
+        rows = mock.records(CID)
+        return [aggregate_pb2.AggregateResponse(data=_codec.records_to_bytes(rows))]
+
+    mock.on(AGG, _agg)
+
+    q = client.data.query("monthly-revenue")
+    assert q.query_id == old_id  # resolves + caches old_id
+    mock.seed_query("monthly-revenue", collection=CID, id=new_id)  # name remapped
+
+    df = q.read()  # first attempt hits old_id -> NOT_FOUND -> re-resolve
+    assert list(df["revenue"]) == [100]
+    assert q.query_id == new_id
+
+
+def test_query_not_found_after_first_chunk_is_not_retried(cf) -> None:
+    """A NOT_FOUND once rows have streamed surfaces raw — no silent replay.
+
+    The QueryHandle counterpart to the collection mid-stream test: re-resolving
+    after rows were yielded would re-deliver them, so the retry is limited to a
+    NOT_FOUND on the probing first chunk.
+    """
+    client, mock = cf
+    from clappform import _codec
+    from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+
+    mock.seed(CID, [{"r": 1}])
+    mock.seed_query("monthly-revenue", collection=CID, id=QID)
+
+    def _agg(_request):
+        def _stream():
+            yield aggregate_pb2.AggregateResponse(
+                data=_codec.records_to_bytes([{"r": 1}])
+            )
+            raise NotFoundError("query vanished mid-scan", location="acme")
+
+        return _stream()
+
+    mock.on(AGG, _agg)
+    with pytest.raises(NotFoundError, match="mid-scan"):
+        client.data.query("monthly-revenue").read()

--- a/tests/test_transport_grpc.py
+++ b/tests/test_transport_grpc.py
@@ -41,6 +41,12 @@ class InsertServicer(insert_pb2_grpc.InsertManagementServicer):
 
 class AggregateServicer(aggregate_pb2_grpc.AggregateManagementServicer):
     def AggregateStream(self, request, context):
+        if request.collection == "vanishes":
+            # Yield one chunk, then fail mid-stream. Exercises the transport's
+            # translating iterator, which must map the error raised *during*
+            # iteration onto the typed hierarchy — not just errors at call time.
+            yield aggregate_pb2.AggregateResponse(data=b"[1]", total=3)
+            context.abort(grpc.StatusCode.NOT_FOUND, "collection vanished mid-scan")
         for chunk in (b"[1]", b"[2]", b"[3]"):
             yield aggregate_pb2.AggregateResponse(data=chunk, total=3)
 
@@ -93,6 +99,17 @@ def test_server_streaming_iterates_chunks(cf) -> None:
     chunks = list(cf.data.aggregate.aggregate_stream(collection="orders"))
     assert [c.data for c in chunks] == [b"[1]", b"[2]", b"[3]"]
     assert chunks[0].total == 3
+
+
+def test_streaming_error_mid_iteration_is_translated(cf) -> None:
+    stream = cf.data.aggregate.aggregate_stream(collection="vanishes")
+    first = next(stream)
+    assert first.data == b"[1]"  # one chunk streamed before the failure
+    with pytest.raises(NotFoundError, match="collection vanished mid-scan") as excinfo:
+        next(stream)
+    # context carried through even though the error surfaced mid-iteration
+    assert "cluster='qa'" in str(excinfo.value)
+    assert "location='acme'" in str(excinfo.value)
 
 
 def test_not_found_translates(cf) -> None:


### PR DESCRIPTION
## Summary

Adds a coverage gate to CI and closes the error/edge-path test gaps found in a coverage audit of the package. Also fixes a real crash in the JSON codec when encoding pandas `NA`.

## Codec fix — pandas `NA` crash

`_codec._normalise_value` used `value != value` as its missing-value sentinel check. For pandas `NA`, `NA != NA` returns `NA` (not a bool) and coercing that to bool raises `TypeError: boolean value of NA is ambiguous`. Any DataFrame using nullable dtypes (`Int64`, nullable `string`, anything from `convert_dtypes()`) produces `NA` for missing cells, so those frames **crashed on encode** instead of writing `null`.

The check now goes through a helper that treats a non-bool or raising self-comparison as missing — only NaN/NaT/NA-style values behave that way. Regression tests include the realistic nullable-dtype frame path.

## Coverage config + CI

- `pytest-cov` added to `[dev]`; `[tool.coverage.*]` config omits the generated `gen/` and `services/` layers (covered by behaviour and golden tests, not per-method line coverage) and gates the hand-written surface at `fail_under = 90` (currently ~97%).
- CI test job runs `pytest --cov`. `pull_request:` has no branch filter, so the gate enforces on **all PRs**.

## Test gaps closed

- `QueryHandle` stale-UUID re-resolution + no-retry-after-first-chunk guard (the `CollectionHandle` counterparts were tested; the query ones weren't).
- Per-location query cache reuse.
- Transport-level error translation when a stream fails **mid-iteration** (previously only exercised via the mock, not the real `GrpcTransport`).
- `with_location("")` guard.
- numpy-NaT and extended-JSON codec edge branches.

## Verification

`ruff`, `mypy` (214 files), and the full suite (164 tests) pass; coverage gate satisfied at 96.89%.