### PR TITLE
test: in-process gRPC fake harness for full-stack client coverage

### DIFF
--- a/tests/_grpc_fakes.py
+++ b/tests/_grpc_fakes.py
@@ -1,0 +1,250 @@
+"""In-process gRPC servers used to exercise the full client stack.
+
+These servicers implement the generated gRPC service base classes with just
+enough canned logic to drive real client flows — pagination, DataFrame
+round-trips, slug resolution, streaming, and retries — over a genuine
+127.0.0.1 channel. Because the client talks to them through its production
+transport, every test that uses them covers interceptors (metadata), the
+codec, retry configuration, and error translation, not just the wrapper layer.
+
+Nothing here reaches the network beyond loopback. A single :class:`FakeCluster`
+bundles every servicer a test might need behind one address, so a client can
+be pointed at it with ``endpoints={...}`` for all families.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from concurrent import futures
+from dataclasses import dataclass, field
+from typing import Any
+
+import grpc
+
+from clappform import _codec
+from clappform.gen.clappform.client.v1.collection import (
+    collection_pb2,
+    collection_pb2_grpc,
+)
+from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2, aggregate_pb2_grpc
+from clappform.gen.clappform.data.v1.insert import insert_pb2, insert_pb2_grpc
+from clappform.gen.clappform.v1.commons import commons_pb2
+
+
+def location_of(context: grpc.ServicerContext) -> str:
+    """Read the tenant ``location`` header the client is required to send."""
+    return dict(context.invocation_metadata()).get("location", "")
+
+
+@dataclass
+class CollectionStore:
+    """State for a single collection keyed by UUID: its slug and its rows.
+
+    ``fail_unavailable`` makes the first N reads of this collection abort with
+    ``UNAVAILABLE`` before succeeding, so retry behaviour can be driven without
+    depending on wall-clock timing.
+    """
+
+    slug: str
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    fail_unavailable: int = 0
+
+
+class CollectionListServicer(collection_pb2_grpc.CollectionManagementServicer):
+    """Serves the paginated listing the slug resolver walks.
+
+    ``GetAll`` pages a fixed number of collections per request so the client's
+    ``iter_get_all`` auto-pagination is genuinely exercised — more than one
+    page, terminating when ``page >= pages``. The listing is location-scoped:
+    a tenant only sees the collections registered for it, which is what lets
+    the per-location resolver cache be tested end-to-end.
+    """
+
+    def __init__(self, page_size: int = 2) -> None:
+        self.page_size = page_size
+        # location -> {uuid: CollectionStore}
+        self._by_location: dict[str, dict[str, CollectionStore]] = {}
+        self.get_all_calls = 0
+
+    def register(self, location: str, uuid: str, store: CollectionStore) -> None:
+        self._by_location.setdefault(location, {})[uuid] = store
+
+    def store_for(self, location: str, uuid: str) -> CollectionStore | None:
+        return self._by_location.get(location, {}).get(uuid)
+
+    def all_for(self, location: str) -> dict[str, CollectionStore]:
+        return self._by_location.get(location, {})
+
+    def GetAll(self, request, context):  # noqa: N802 - gRPC servicer name
+        self.get_all_calls += 1
+        location = location_of(context)
+        collections = [
+            collection_pb2.Collection(id=uuid, slug=store.slug)
+            for uuid, store in self.all_for(location).items()
+        ]
+        page = request.page or 1
+        pages = max(1, (len(collections) + self.page_size - 1) // self.page_size)
+        start = (page - 1) * self.page_size
+        window = collections[start : start + self.page_size]
+        return collection_pb2.Collections(
+            collections=window,
+            pagination=commons_pb2.Pagination(
+                page=page, pages=pages, total=len(collections)
+            ),
+        )
+
+
+class AggregateReadServicer(aggregate_pb2_grpc.AggregateManagementServicer):
+    """Streams a collection's rows back as JSON-encoded ``AggregateResponse``s.
+
+    Rows are looked up by the request's ``collection`` UUID (or, for saved
+    queries, resolved by the ``query`` UUID to a backing collection), encoded
+    through the real codec, and chunked so the streaming path and the
+    ReadResult batching are both driven. A collection whose store carries
+    ``fail_unavailable=N`` aborts with ``UNAVAILABLE`` on its first N reads
+    before succeeding, which is how retry behaviour is tested without touching
+    timing. ``attempts`` records reads per UUID so tests can assert how many
+    attempts the retry policy made.
+    """
+
+    def __init__(self, collections: CollectionListServicer) -> None:
+        self._collections = collections
+        self._query_to_collection: dict[str, str] = {}
+        self.attempts: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def register_query(self, query_uuid: str, collection_uuid: str) -> None:
+        self._query_to_collection[query_uuid] = collection_uuid
+
+    def _store_for(self, location: str, request) -> CollectionStore | None:
+        uuid = request.collection
+        if request.query:
+            uuid = self._query_to_collection.get(request.query, "")
+        return self._collections.store_for(location, uuid)
+
+    def AggregateStream(self, request, context):  # noqa: N802
+        location = location_of(context)
+        store = self._store_for(location, request)
+        uuid = request.query or request.collection
+        with self._lock:
+            seen = self.attempts.get(uuid, 0) + 1
+            self.attempts[uuid] = seen
+        if store is not None and seen <= store.fail_unavailable:
+            context.abort(grpc.StatusCode.UNAVAILABLE, "cluster warming up")
+        rows = list(store.rows) if store is not None else []
+        if not rows:
+            yield aggregate_pb2.AggregateResponse(data=b"[]", total=0)
+            return
+        # One record per chunk so the ReadResult batching has multiple chunks.
+        for row in rows:
+            yield aggregate_pb2.AggregateResponse(
+                data=_codec.records_to_bytes([row]), total=len(rows)
+            )
+
+
+class InsertServicer(insert_pb2_grpc.InsertManagementServicer):
+    """Client-streaming insert that appends decoded rows into a store.
+
+    ``InsertMany`` consumes the request iterator (each carrying a JSON chunk),
+    appends the decoded records to the matching collection, and returns one
+    ``InsertResponse`` per request with the rows processed and assigned oids —
+    enough for the DataFrame ``append`` round-trip and for asserting the
+    ``location`` header arrives on a client-streaming call.
+    """
+
+    def __init__(self, collections: CollectionListServicer) -> None:
+        self._collections = collections
+        self.seen_location: str | None = None
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    def _store(self, location: str, uuid: str) -> CollectionStore | None:
+        return self._collections.store_for(location, uuid)
+
+    def InsertMany(self, request_iterator, context):  # noqa: N802
+        self.seen_location = location_of(context)
+        for request in request_iterator:
+            records = _codec.bytes_to_records(request.data)
+            store = self._store(self.seen_location, request.collection)
+            oids = []
+            for record in records:
+                with self._lock:
+                    self._counter += 1
+                    oid = f"oid-{self._counter}"
+                record = {"_id": oid, **record}
+                if store is not None:
+                    store.rows.append(record)
+                oids.append(oid)
+            yield insert_pb2.InsertResponse(
+                processed_count=len(records), oids=oids
+            )
+
+
+@dataclass
+class FakeCluster:
+    """A started in-process gRPC server exposing every fake servicer.
+
+    Every API family (``data``, ``client``, ...) is pointed at this one
+    address, so a client built with ``endpoints=cluster.endpoints`` routes all
+    calls here. ``address`` is loopback-only.
+    """
+
+    server: grpc.Server
+    address: str
+    collections: CollectionListServicer
+    aggregate: AggregateReadServicer
+    insert: InsertServicer
+
+    @property
+    def endpoints(self) -> dict[str, str]:
+        return {family: self.address for family in ("data", "client", "auth", "notifier")}
+
+    def register_collection(
+        self,
+        *,
+        location: str,
+        uuid: str,
+        slug: str,
+        rows: list[dict[str, Any]],
+        fail_unavailable: int = 0,
+    ) -> None:
+        self.collections.register(
+            location,
+            uuid,
+            CollectionStore(slug=slug, rows=rows, fail_unavailable=fail_unavailable),
+        )
+
+    def register_query(
+        self, *, query_uuid: str, collection_uuid: str
+    ) -> None:
+        self.aggregate.register_query(query_uuid, collection_uuid)
+
+    def stop(self) -> None:
+        self.server.stop(grace=None)
+
+
+def start_fake_cluster(page_size: int = 2) -> FakeCluster:
+    """Build, wire, and start a :class:`FakeCluster` on a free loopback port."""
+    collections = CollectionListServicer(page_size=page_size)
+    aggregate = AggregateReadServicer(collections)
+    insert = InsertServicer(collections)
+
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=8))
+    collection_pb2_grpc.add_CollectionManagementServicer_to_server(collections, server)
+    aggregate_pb2_grpc.add_AggregateManagementServicer_to_server(aggregate, server)
+    insert_pb2_grpc.add_InsertManagementServicer_to_server(insert, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    return FakeCluster(
+        server=server,
+        address=f"127.0.0.1:{port}",
+        collections=collections,
+        aggregate=aggregate,
+        insert=insert,
+    )
+
+
+def drain(stream: Iterator[Any]) -> list[Any]:
+    """Materialise a streaming response, for tests that assert on all chunks."""
+    return list(stream)

--- a/tests/test_contract_smoke.py
+++ b/tests/test_contract_smoke.py
@@ -1,0 +1,72 @@
+"""Contract smoke test against a live staging cluster.
+
+Fakes prove the client stack is internally consistent; they cannot catch
+drift between the client and a real server (a field renamed server-side, an
+RPC a cluster does not yet serve, an auth or location-header expectation that
+changed). This test dials a real staging cluster to catch exactly that.
+
+It is **skipped unless** ``CLAPPFORM_CONTRACT_SMOKE`` is set, because it needs
+network access and real credentials, so it never runs in the normal unit-test
+suite (local or PR CI). The intended home is the proto-sync workflow, which
+runs after regenerating stubs from a new ``commons`` tag — the one moment
+client/server drift can appear. Point it at staging with:
+
+    CLAPPFORM_CONTRACT_SMOKE=1
+    CLAPPFORM_SMOKE_LOCATION=<tenant subdomain>
+    CLAPPFORM_SMOKE_API_KEY=<staging api key>
+    CLAPPFORM_SMOKE_CLUSTER=<cluster extension>   # optional; DNS-discovered if unset
+
+The assertions stay deliberately shallow — a real round-trip and clean
+teardown — so the test flags drift without depending on any tenant's data.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from clappform import Clappform, ClappformError
+
+_SMOKE_ENABLED = os.environ.get("CLAPPFORM_CONTRACT_SMOKE")
+
+pytestmark = pytest.mark.skipif(
+    not _SMOKE_ENABLED,
+    reason="contract smoke test runs only when CLAPPFORM_CONTRACT_SMOKE is set "
+    "(proto-sync workflow); needs a live staging cluster and credentials",
+)
+
+
+def _require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.fail(
+            f"contract smoke test needs {name}; set it alongside "
+            "CLAPPFORM_CONTRACT_SMOKE in the proto-sync workflow"
+        )
+    return value
+
+
+@pytest.fixture
+def staging_client():
+    location = _require("CLAPPFORM_SMOKE_LOCATION")
+    api_key = _require("CLAPPFORM_SMOKE_API_KEY")
+    cluster = os.environ.get("CLAPPFORM_SMOKE_CLUSTER")
+    kwargs = {"api_key": api_key}
+    if cluster is not None:
+        kwargs["cluster"] = cluster
+    client = Clappform(location, **kwargs)
+    yield client
+    client.close()
+
+
+def test_staging_collections_listing_round_trips(staging_client) -> None:
+    """List collections against staging: proves auth, location header, and the
+    collection listing wire shape all still line up with the live server."""
+    try:
+        page = staging_client.client.collection.get_all(page=1, limit=1)
+    except ClappformError as exc:  # surface a typed failure, not a raw grpc error
+        pytest.fail(f"staging contract check failed: {exc}")
+    # Shape, not contents: pagination must be populated regardless of tenant data.
+    assert page.pagination.page >= 1
+    assert page.pagination.pages >= 0

--- a/tests/test_grpc_harness.py
+++ b/tests/test_grpc_harness.py
@@ -1,0 +1,217 @@
+"""Full-stack coverage through in-process gRPC servers.
+
+Where ``test_transport_grpc.py`` proves the transport primitives (metadata,
+deadlines, error translation, streaming), this module drives the higher-level
+flows — pagination, DataFrame round-trips, slug resolution and its cache, and
+retry-on-UNAVAILABLE — against real generated servicers over a loopback
+channel. Every assertion therefore exercises the whole client stack:
+interceptors, codec, retry service config, and error translation together, not
+a mocked transport.
+
+The fakes live in ``tests/_grpc_fakes.py``; each test points a ``Clappform``
+at one :class:`FakeCluster` address for all API families.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _grpc_fakes import start_fake_cluster
+
+from clappform import Clappform, NotFoundError, TransientError
+from clappform._transport import RetryPolicy
+
+CID = "1c9a7f3e-0000-4000-8000-000000000001"
+CID2 = "2222aaaa-0000-4000-8000-000000000002"
+QID = "8f14e45f-ceea-467f-a34e-95b7f7f7a9d1"
+
+
+@pytest.fixture
+def cluster():
+    fake = start_fake_cluster()
+    yield fake
+    fake.stop()
+
+
+def _client(cluster, *, retries: RetryPolicy | None = None, **kwargs) -> Clappform:
+    return Clappform(
+        "acme",
+        "qa",
+        api_key="test-key",
+        endpoints=cluster.endpoints,
+        insecure=True,
+        timeout=5.0,
+        retries=retries,
+        **kwargs,
+    )
+
+
+# -- location metadata on a client-streaming call ------------------------
+
+
+def test_client_streaming_carries_location_metadata(cluster) -> None:
+    """The location header must ride client-streaming RPCs, not only unary ones."""
+    import pandas as pd
+
+    cluster.register_collection(location="acme", uuid=CID, slug="orders", rows=[])
+    with _client(cluster) as cf:
+        written = cf.data.collection(CID).append(pd.DataFrame([{"amount": 10}]))
+    assert written == 1
+    assert cluster.insert.seen_location == "acme"
+
+
+def test_client_streaming_location_override_wins(cluster) -> None:
+    import pandas as pd
+
+    cluster.register_collection(location="umbrella", uuid=CID, slug="orders", rows=[])
+    with _client(cluster) as cf:
+        cf.with_location("umbrella").data.collection(CID).append(
+            pd.DataFrame([{"amount": 5}])
+        )
+    assert cluster.insert.seen_location == "umbrella"
+
+
+# -- pagination iterator over the real wire ------------------------------
+
+
+def test_iter_get_all_walks_every_page(cluster) -> None:
+    """The auto-pagination iterator must follow ``Pagination`` across pages.
+
+    The fake serves 2 collections per page, so five collections span three
+    pages; the iterator must yield all five and stop when page == pages.
+    """
+    slugs = [f"c{i}" for i in range(5)]
+    for i, slug in enumerate(slugs):
+        cluster.register_collection(
+            location="acme", uuid=f"{i}0000000-0000-4000-8000-000000000000", slug=slug, rows=[]
+        )
+    with _client(cluster) as cf:
+        seen = [c.slug for c in cf.client.collection.iter_get_all()]
+    assert sorted(seen) == sorted(slugs)
+    assert cluster.collections.get_all_calls == 3  # ceil(5 / 2) pages
+
+
+# -- DataFrame round-trip through append + read --------------------------
+
+
+def test_dataframe_round_trip_append_then_read(cluster) -> None:
+    """Rows appended via InsertMany read back byte-identical through AggregateStream."""
+    import pandas as pd
+
+    cluster.register_collection(location="acme", uuid=CID, slug="orders", rows=[])
+    with _client(cluster) as cf:
+        col = cf.data.collection(CID)
+        col.append(pd.DataFrame([{"region": "eu", "amount": 10}, {"region": "us", "amount": 20}]))
+        df = col.read()
+    assert sorted(df["region"]) == ["eu", "us"]
+    assert sorted(df["amount"]) == [10, 20]
+    assert "_id" in df.columns  # id preserved so a later update() round-trips
+
+
+def test_read_streams_chunks_into_readresult(cluster) -> None:
+    cluster.register_collection(
+        location="acme",
+        uuid=CID,
+        slug="orders",
+        rows=[{"n": 1}, {"n": 2}, {"n": 3}],
+    )
+    with _client(cluster) as cf:
+        batches = list(cf.data.collection(CID).iter_batches())
+    # one row per chunk from the fake -> three batches, all rows present
+    assert sum(len(b) for b in batches) == 3
+    assert len(batches) == 3
+
+
+# -- slug resolution + cache through the real Client API -----------------
+
+
+def test_slug_resolves_via_listing_and_reads(cluster) -> None:
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="sales_orders", rows=[{"n": 1}, {"n": 2}]
+    )
+    with _client(cluster) as cf:
+        col = cf.data.collection("sales_orders")
+        assert len(col.read()) == 2
+        assert col.collection_id == CID
+
+
+def test_slug_resolution_cached_across_reads(cluster) -> None:
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="sales_orders", rows=[{"n": 1}]
+    )
+    with _client(cluster) as cf:
+        col = cf.data.collection("sales_orders")
+        col.read()
+        col.read()
+        col.read()
+    # one listing consulted for the slug, cached thereafter (per process)
+    assert cluster.collections.get_all_calls == 1
+
+
+def test_unknown_slug_raises_naming_slug_and_location(cluster) -> None:
+    cluster.register_collection(location="acme", uuid=CID, slug="exists", rows=[])
+    with _client(cluster) as cf, pytest.raises(NotFoundError, match="ghost") as exc:
+        cf.data.collection("ghost").read()
+    assert "acme" in str(exc.value)
+
+
+def test_slug_cache_is_isolated_per_location(cluster) -> None:
+    """A slug resolved for one tenant must not leak into another's cache."""
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="orders", rows=[{"who": "acme"}]
+    )
+    cluster.register_collection(
+        location="umbrella", uuid=CID2, slug="orders", rows=[{"who": "umbrella"}]
+    )
+    with _client(cluster) as cf:
+        assert cf.data.collection("orders").collection_id == CID
+        assert cf.with_location("umbrella").data.collection("orders").collection_id == CID2
+
+
+def test_saved_query_reads_backing_collection(cluster) -> None:
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="orders", rows=[{"revenue": 100}]
+    )
+    cluster.register_query(query_uuid=QID, collection_uuid=CID)
+    with _client(cluster) as cf:
+        df = cf.data.query(QID).read()
+    assert list(df["revenue"]) == [100]
+
+
+# -- retry behaviour on UNAVAILABLE --------------------------------------
+
+
+def test_unavailable_is_retried_then_succeeds(cluster) -> None:
+    """A read that UNAVAILABLEs once must transparently retry and then succeed.
+
+    The fake fails the collection's first read and serves rows on the retry;
+    with a 3-attempt policy the client's built-in retry config must absorb the
+    failure so the caller never sees it.
+    """
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="warming", rows=[{"n": 1}], fail_unavailable=1
+    )
+    with _client(cluster, retries=RetryPolicy(max_attempts=3)) as cf:
+        df = cf.data.collection(CID).read()
+    assert list(df["n"]) == [1]
+    assert cluster.aggregate.attempts[CID] == 2  # failed once, retried once
+
+
+def test_unavailable_surfaces_as_transient_when_retries_exhausted(cluster) -> None:
+    """When failures outlast the attempt budget, the typed TransientError shows."""
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="down", rows=[{"n": 1}], fail_unavailable=5
+    )
+    with _client(cluster, retries=RetryPolicy(max_attempts=2)) as cf, pytest.raises(
+        TransientError
+    ):
+        cf.data.collection(CID).read()
+
+
+def test_no_retry_policy_does_not_retry_unavailable(cluster) -> None:
+    """With retries disabled, the very first UNAVAILABLE surfaces immediately."""
+    cluster.register_collection(
+        location="acme", uuid=CID, slug="down", rows=[{"n": 1}], fail_unavailable=1
+    )
+    with _client(cluster, retries=None) as cf, pytest.raises(TransientError):
+        cf.data.collection(CID).read()
+    assert cluster.aggregate.attempts[CID] == 1  # no second attempt


### PR DESCRIPTION
## Summary

- Add `tests/_grpc_fakes.py`: reusable, stateful in-process gRPC servicers (collection listing, aggregate read, client-streaming insert) behind one `FakeCluster` address, holding real per-location collection state.
- Add `tests/test_grpc_harness.py`: drives the coverage targets over a real loopback channel — location metadata on client-streaming calls, multi-page auto-pagination, the DataFrame append/read round-trip, slug resolution + its per-location cache, and retry-on-UNAVAILABLE (retried→succeeds, exhausted→`TransientError`, and no-retry when disabled).
- Add `tests/test_contract_smoke.py`: env-gated (`CLAPPFORM_CONTRACT_SMOKE`) smoke test against a live staging cluster to catch client/server drift the fakes cannot; skipped in the normal suite.
- All flows run through the production transport, so interceptors, the codec, retry service config, and error translation are exercised together rather than mocked.

## Related issues

- Closes #45 — v6: unit test harness — in-process gRPC fakes

## Tests

- New: `tests/_grpc_fakes.py`, `tests/test_grpc_harness.py` (13 cases), `tests/test_contract_smoke.py` (1 case, skipped unless env-gated).
- `python -m ruff check .`, `python -m mypy src/clappform tools`, and `python -m pytest -q --cov` all passing locally — 177 passed, 1 skipped, coverage 96.98% (gate 90%).

## Notes

- Design doc: `DESIGN.md` §8 (Testing strategy) is the plan of record for this work.
- The contract smoke test is written to run in the proto-sync workflow (DESIGN §4.3), which does not exist in this repo yet. Follow-up: wire `CLAPPFORM_CONTRACT_SMOKE` and the staging credentials into that workflow once it lands; until then the test stays skipped everywhere.
- Retry-on-UNAVAILABLE is driven deterministically (a per-collection failure counter aborts before the first stream message, which is the point at which gRPC's built-in retry applies) rather than via timing, so the tests are not flaky.