### PR TITLE
docs: MkDocs Material on Read the Docs with a generated, CI-tested reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,22 @@ jobs:
       # --cov enforces the fail_under gate in [tool.coverage.report] on every
       # PR (pull_request above has no branch filter, so this runs on all PRs).
       - run: python -m pytest -q --cov --cov-report=term-missing
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      # pandas is needed so the docstring reference imports the DataFrame surface
+      # and so the documented snippets run.
+      - run: python -m pip install -e .[dev,docs,pandas]
+      # Run every documented snippet against LocalMock. A guide example that
+      # breaks fails here before the site is ever built.
+      - run: python -m pytest -q tests/test_docs_snippets.py
+      # Build the site with --strict so a broken snippet include, a dead
+      # reference, or a nav typo fails the build rather than shipping silently.
+      - run: python -m mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 dist/
 *.egg-info/
 
+# MkDocs build output
+/site/
+
 # Virtual environments
 .venv/
 venv/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# Read the Docs build configuration.
+#
+# Docs live in this repo and build with MkDocs (RTD supports MkDocs natively),
+# so the existing clappform.readthedocs.io domain and its search index carry
+# over. Per §9 the reference is generated from the wrapper layer's docstrings,
+# which means the package has to be importable at build time — hence the editable
+# install with the docs and pandas extras below.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - pandas

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate lint typecheck test check build clean
+.PHONY: generate lint typecheck test check build clean docs docs-serve docs-test
 
 generate:
 	python tools/generate.py
@@ -17,5 +17,16 @@ check: lint typecheck test
 build:
 	python -m build
 
+# Run the documented snippets against LocalMock, then build the site strictly
+# (a broken include, dead reference or nav typo fails the build).
+docs-test:
+	python -m pytest -q tests/test_docs_snippets.py
+
+docs: docs-test
+	python -m mkdocs build --strict
+
+docs-serve:
+	python -m mkdocs serve
+
 clean:
-	rm -rf dist build src/clappform.egg-info .pytest_cache .mypy_cache .ruff_cache
+	rm -rf dist build site src/clappform.egg-info .pytest_cache .mypy_cache .ruff_cache

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,33 @@
+# Changelog
+
+The client pins the `commons` proto repo by git tag, so every release records
+the proto version it was generated against — a client's behaviour is a function
+of both its own version and the protos it wraps. `clappform.__proto_version__`
+reports the pinned proto tag at runtime, and `repr(client)` includes it.
+
+!!! note "Per-release entries"
+    Release entries — including each release's proto diff — are published from
+    the release workflow that also pushes to PyPI, so this page fills in as
+    versions ship. The versions below track the 6.x line; the 4.x HTTP-era docs
+    remain archived under their own version tag.
+
+## 6.0.0 (alpha)
+
+The greenfield rewrite. One package covering every Clappform gRPC API,
+generated from the `commons` protos, with:
+
+- A single `Clappform` client, one binding per `(cluster, location,
+  credentials)`, with namespaced sub-clients (`data`, `client`, `auth`,
+  `notifier`).
+- First-class pandas DataFrame flows (`read` / `append` / `update` / `upsert` /
+  `replace_where` / `delete`) and saved-query reads.
+- Native multi-cluster / multi-tenant support with optional DNS-based cluster
+  discovery.
+- A typed error hierarchy that never leaks `grpc` to the caller.
+- `LocalMock`, an in-process transport double for testing without
+  infrastructure.
+
+Configuration is constructor-only (no config files, no environment lookup) and
+API-key auth is the only credential shipped in this line. Async, JWT/SSO auth,
+the `nbflow` API, and Arrow/Polars output surfaces are designed-for but not yet
+shipped.

--- a/docs/guides/dataframes.md
+++ b/docs/guides/dataframes.md
@@ -1,0 +1,82 @@
+# DataFrame flows
+
+The DataFrame surface is what you reach for day to day. A
+[`CollectionHandle`][clappform.CollectionHandle] holds only a client and a
+reference — no connection, no state — and every flow runs over the streaming
+data RPCs.
+
+Get one from `cf.data.collection(ref)`, where `ref` is a slug or a UUID
+(resolved once and cached per tenant).
+
+## Read into a DataFrame
+
+`read()` streams the collection (or a filtered slice) into pandas. `where`,
+`fields` and `limit` are client-side sugar compiled into a
+`$match` / `$project` / `$limit` pipeline — the API never sees the kwargs.
+
+```python
+--8<-- "dataframes.py:read"
+```
+
+`_id` is kept as a column so the frame round-trips through `update()`. An empty
+result yields an empty frame, never an error.
+
+### Aggregation the sugar doesn't cover
+
+For stages `where` / `fields` / `limit` don't emit — `$group`, `$sort`, or an
+Elastic-backed collection's DSL — pass a full pipeline with `aggregate()`. It is
+sent through untouched.
+
+```python
+--8<-- "dataframes.py:aggregate"
+```
+
+### Memory-bounded reads
+
+For a result set too big to hold at once, `iter_batches()` yields one list of
+records per gRPC chunk. `batch_size` asks the server to cap each chunk.
+
+```python
+--8<-- "dataframes.py:batches"
+```
+
+!!! note "A read streams once"
+    `fetch()` returns a [`ReadResult`][clappform.ReadResult] that is single-pass
+    — iterate it or convert it exactly once. `read()` and `iter_batches()` are
+    thin wrappers (`read()` is literally `fetch().to_pandas()`); call `read()`
+    again for a fresh pass rather than reusing a materialised result.
+
+## Write back
+
+`update()` matches on `_id` by default; `append()` inserts new rows; `upsert()`
+inserts-or-updates on a business key (which has no default — you must pass
+`on=`). Uploads stream in chunks, so a failed chunk is retryable at the flow
+level rather than a whole-frame resend.
+
+```python
+--8<-- "dataframes.py:write"
+```
+
+## Server-side mutate and delete
+
+When you don't need the rows client-side, `replace_where()` and `delete()` run
+entirely on the server — nothing is round-tripped through the client. To wipe a
+collection use `clear()`, which is explicit by design so a full delete is never
+an accident of an empty filter.
+
+```python
+--8<-- "dataframes.py:server-side"
+```
+
+## Saved queries
+
+A saved server-side query carries its own collection and pipeline, so a
+[`QueryHandle`][clappform.QueryHandle] is read-only: `cf.data.query(ref)` where
+`ref` is the query's name or UUID.
+
+```python
+--8<-- "dataframes.py:saved-query"
+```
+
+See the [DataFrame surface reference](../reference/dataframes.md) for every
+method and argument.

--- a/docs/guides/errors-and-retries.md
+++ b/docs/guides/errors-and-retries.md
@@ -1,0 +1,48 @@
+# Error handling & retries
+
+Every failure the client raises derives from
+[`ClappformError`][clappform.ClappformError] and carries the call context —
+method, cluster, location — so you never import `grpc` to handle one, and the
+message always says which tenant on which cluster failed.
+
+## The typed hierarchy
+
+gRPC status codes are mapped onto specific exception types:
+
+| Exception | gRPC status | Meaning |
+|---|---|---|
+| [`ConfigurationError`][clappform.ConfigurationError] | (pre-flight / missing header) | Bad endpoints, credentials, or a missing tenant header — often raised before any RPC |
+| [`AuthenticationError`][clappform.AuthenticationError] | `UNAUTHENTICATED` | The credential was rejected |
+| [`PermissionDeniedError`][clappform.PermissionDeniedError] | `PERMISSION_DENIED` | Authenticated, but not allowed |
+| [`NotFoundError`][clappform.NotFoundError] | `NOT_FOUND` | The referenced entity does not exist |
+| [`InvalidRequestError`][clappform.InvalidRequestError] | `INVALID_ARGUMENT` / `FAILED_PRECONDITION` / `OUT_OF_RANGE` | Malformed request or violated precondition |
+| [`ConflictError`][clappform.ConflictError] | `ALREADY_EXISTS` / `ABORTED` | Conflicts with existing state |
+| [`NotSupportedError`][clappform.NotSupportedError] | `UNIMPLEMENTED` | This cluster doesn't serve the RPC yet (staggered rollouts) |
+| [`TransientError`][clappform.TransientError] | `UNAVAILABLE` / `DEADLINE_EXCEEDED` | Retryable failure, retries exhausted |
+
+## Catching errors
+
+Catch the specific type you can act on and let the rest propagate:
+
+```python
+--8<-- "errors_and_retries.py:typed-errors"
+```
+
+## Retries
+
+Retries are configured once on the client and applied by gRPC's built-in retry
+support. The default, `clappform.DEFAULT_RETRIES`, retries `UNAVAILABLE` with
+exponential backoff. Override it per client with a
+[`RetryPolicy`][clappform.RetryPolicy], or pass `retries=None` to disable.
+
+```python
+--8<-- "errors_and_retries.py:retry-policy"
+```
+
+!!! warning "Retries and streaming writes"
+    Chunked uploads (`append`, `update`, `upsert`) stream in chunks, so a failed
+    chunk is retryable at the flow level. When a `TransientError` escapes after
+    retries are exhausted, retry the whole flow rather than a single chunk — the
+    write is designed to be safe to re-run.
+
+See the [Errors reference](../reference/errors.md) for the full hierarchy.

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -1,0 +1,57 @@
+# Multi-cluster & multi-tenant
+
+Cluster and tenant are independent axes. The **cluster** (the host extension:
+`""`, `"qa"`, `"qa-lts"`, `"prod"`, …) picks the endpoints. The **tenant**
+(`location`) picks the database within them and is sent as metadata on every
+call. Nothing is global, so any combination coexists in one process.
+
+## Two clusters, one process
+
+Each client is its own binding with its own credentials. Point one at prod and
+one at qa and use them side by side:
+
+```python
+--8<-- "multi_cluster.py:two-clusters"
+```
+
+Omit `cluster=` and the client discovers it from the DNS CNAME of
+`{location}.clappform.com`. An explicit `cluster=` always wins — pass it in
+air-gapped or split-DNS environments where discovery can't run.
+
+## Copying across clusters
+
+Because both clients are just objects, a cross-cluster copy is a read on one and
+a write on the other:
+
+```python
+--8<-- "multi_cluster.py:cross-cluster"
+```
+
+## Another tenant on the same cluster
+
+`with_location()` gives a cheap clone bound to a different tenant. When the
+cluster is known (explicit, or a custom transport) the clone shares the parent's
+connections and configuration — only the tenant metadata differs, and no DNS is
+performed.
+
+```python
+--8<-- "multi_cluster.py:with-location"
+```
+
+!!! note "Discovered clusters may re-discover"
+    If the parent's cluster was *discovered* (no `cluster=`), a different
+    location is re-resolved: if it lands on the same cluster the transport is
+    still shared, otherwise the clone gets its own transport for its own
+    cluster. With an explicitly configured cluster, `with_location()` never
+    performs DNS.
+
+## Staggered rollouts
+
+Clusters update at different times, so a newer client may call an RPC an older
+cluster doesn't serve yet — that surfaces as
+[`NotSupportedError`][clappform.NotSupportedError] (gRPC `UNIMPLEMENTED`), not a
+crash. Handle it where you rely on a just-added RPC; see
+[Error handling & retries](errors-and-retries.md).
+
+See the [Client reference](../reference/client.md) for the full constructor and
+`with_location()` signature.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,50 @@
+# Testing with LocalMock
+
+[`LocalMock`][clappform.testing.LocalMock] is an in-process transport double. It
+implements the same transport seam the real client uses, so it plugs straight
+into `Clappform(transport=LocalMock())` and every service method works against
+it — no network, no infrastructure, no keys that matter.
+
+Every example in these guides runs against `LocalMock` in CI, so a doc snippet
+that breaks fails the build.
+
+## Seed a data store
+
+`seed()` loads records into a named collection, and built-in handlers for the
+core data RPCs read and mutate that store through the same JSON codec the real
+client uses. Point a client at the mock and the full DataFrame surface
+round-trips:
+
+```python
+--8<-- "testing.py:seed"
+```
+
+```python
+--8<-- "testing.py:roundtrip"
+```
+
+Writes mutate the store, so a follow-up read sees them — which is what lets you
+test a read → mutate → write-back pipeline end to end.
+
+## Assert on the calls made
+
+Every call is recorded on `mock.calls` for assertions — handy for checking the
+right RPC was invoked with the right tenant.
+
+```python
+--8<-- "testing.py:assert-calls"
+```
+
+## Stub any other RPC
+
+The seedable store covers the data plane. For any other RPC, register a canned
+response with `on()`, keyed by the full gRPC method path. It may be a response
+message, a `handler(request)` callable, or (for a streaming RPC) an iterable of
+responses. An explicit stub always wins over a built-in handler.
+
+```python
+--8<-- "testing.py:stub"
+```
+
+See the [Testing reference](../reference/testing.md) for every seeding and
+stubbing method.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# Clappform Python Client
+
+The Python client for the Clappform gRPC APIs. One package, one `Clappform`
+client, first-class pandas DataFrame flows, and native multi-cluster /
+multi-tenant support.
+
+```python
+from clappform import Clappform
+
+cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...")
+df = cf.data.collection("sales_orders").read(where={"status": "open"})
+```
+
+## What this client is
+
+- **DataFrame-first.** Reads stream straight into pandas; writes take a
+  DataFrame back. See [DataFrame flows](guides/dataframes.md).
+- **Nothing global.** Every client is one `(cluster, location, credentials)`
+  binding — two clusters coexist in one process. The library reads no config
+  files and no environment variables; everything is a constructor argument.
+- **Generated from the protos.** The API reference is generated from the
+  wrapper layer's docstrings, which come from the proto comments, so a new RPC
+  appears in these docs in the same release that adds it to the client.
+- **Typed errors.** Every failure derives from `ClappformError` and carries the
+  call context (method, cluster, location) — you never import `grpc` to handle
+  one. See [Error handling & retries](guides/errors-and-retries.md).
+- **Testable without infrastructure.** `LocalMock` is an in-process transport
+  double; the examples in these guides run against it in CI. See
+  [Testing with LocalMock](guides/testing.md).
+
+## Install
+
+```bash
+pip install "clappform[pandas]"
+```
+
+The core install pulls only `grpcio` and `protobuf`; pandas ships in the
+`[pandas]` extra so the DataFrame surface is available.
+
+## Reading these docs
+
+!!! note "Read the docs for your version"
+    Clusters roll out on staggered schedules, so a client that talks to one
+    cluster may be a different version than one talking to another. Use the
+    version selector to read the docs for the client version you are actually
+    running. The 4.x HTTP-era docs remain archived under their version tag.
+
+Start with the [Quickstart](quickstart.md), then reach for the how-to guides
+for a specific flow. The [Reference](reference/client.md) is the generated,
+exhaustive surface.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart
+
+Install, connect, and round-trip a DataFrame in about twenty lines.
+
+## Install
+
+```bash
+pip install "clappform[pandas]"
+```
+
+The core dependencies are just `grpcio` and `protobuf`. pandas comes in the
+`[pandas]` extra, which you want for the DataFrame flows below.
+
+## Connect
+
+A client is one binding: a cluster, a tenant (`location`), and a credential.
+Nothing is read from the environment — you pass everything in.
+
+```python
+--8<-- "quickstart.py:connect"
+```
+
+`cluster` is the host extension (`"prod"`, `"qa"`, `"qa-lts"`, or `""` for the
+main cluster). Omit it and the client discovers it from the DNS record of
+`{location}.clappform.com`; pass it explicitly in air-gapped or split-DNS
+setups. `location` is your tenant subdomain and is sent as metadata on every
+call.
+
+API keys are the only credential v6 ships. Keep the key out of source — read it
+from your own secret store and pass it in.
+
+## Read, mutate, write back
+
+```python
+--8<-- "quickstart.py:roundtrip"
+```
+
+That is the whole loop: `read()` gives you a pandas DataFrame with `_id` kept as
+a column, you change it with plain pandas, and `update()` writes the changed
+rows back — matched on `_id` by default, so the common case needs no arguments.
+
+## Next steps
+
+- [DataFrame flows](guides/dataframes.md) — filtering, batching, append /
+  upsert, server-side updates and deletes.
+- [Multi-cluster & multi-tenant](guides/multi-cluster.md) — several clusters
+  and tenants in one process.
+- [Error handling & retries](guides/errors-and-retries.md) — the typed error
+  hierarchy and retry configuration.
+- [Testing with LocalMock](guides/testing.md) — run your pipelines with no
+  infrastructure.

--- a/docs/reference/api-families.md
+++ b/docs/reference/api-families.md
@@ -1,0 +1,48 @@
+# API families
+
+The four API families hang off the client: `cf.data`, `cf.client`, `cf.auth`,
+and `cf.notifier`. Each is a generated sub-client with one method per RPC, and
+these pages are generated from those wrappers' docstrings — which come from the
+proto comments — so a new RPC appears here in the same release that adds it to
+the client.
+
+For the everyday DataFrame flows on `cf.data`, prefer the
+[DataFrame surface](dataframes.md) (`cf.data.collection(...)` /
+`cf.data.query(...)`); the raw per-RPC methods below are the full generated
+surface underneath it.
+
+## Data — `cf.data`
+
+::: clappform.services.data
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: alphabetical
+      filters: ["!^_", "!API$"]
+
+## Client — `cf.client`
+
+::: clappform.services.client
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: alphabetical
+      filters: ["!^_", "!API$"]
+
+## Authoriser — `cf.auth`
+
+::: clappform.services.auth
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: alphabetical
+      filters: ["!^_", "!API$"]
+
+## Notifier — `cf.notifier`
+
+::: clappform.services.notifier
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: alphabetical
+      filters: ["!^_", "!API$"]

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,0 +1,14 @@
+# Client
+
+The `Clappform` client and its constructor. One instance is one
+`(cluster, location, credentials)` binding; the API families (`cf.data`,
+`cf.client`, `cf.auth`, `cf.notifier`) hang off it. See
+[API families](api-families.md) for the generated per-RPC surface.
+
+::: clappform.Clappform
+
+::: clappform.ApiKey
+
+::: clappform.Credentials
+
+::: clappform.RetryPolicy

--- a/docs/reference/dataframes.md
+++ b/docs/reference/dataframes.md
@@ -1,0 +1,10 @@
+# DataFrame surface
+
+The handles you get from `cf.data.collection(ref)` and `cf.data.query(ref)`,
+plus the `ReadResult` seam their reads return.
+
+::: clappform.CollectionHandle
+
+::: clappform.QueryHandle
+
+::: clappform.ReadResult

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,24 @@
+# Errors
+
+Every error the client raises derives from `ClappformError` and carries the
+call context (method, cluster, location). See
+[Error handling & retries](../guides/errors-and-retries.md) for how the gRPC
+status codes map onto these types.
+
+::: clappform.ClappformError
+
+::: clappform.ConfigurationError
+
+::: clappform.AuthenticationError
+
+::: clappform.PermissionDeniedError
+
+::: clappform.NotFoundError
+
+::: clappform.InvalidRequestError
+
+::: clappform.ConflictError
+
+::: clappform.NotSupportedError
+
+::: clappform.TransientError

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,8 @@
+# Testing
+
+The in-process transport double. See
+[Testing with LocalMock](../guides/testing.md) for a walkthrough.
+
+::: clappform.testing.LocalMock
+
+::: clappform.testing.RecordedCall

--- a/docs/snippets/dataframes.py
+++ b/docs/snippets/dataframes.py
@@ -1,0 +1,108 @@
+"""Runnable source for the DataFrame-flows guide snippets.
+
+Covers the read/filter, batch, append/update/upsert, replace-where and delete
+paths. Runs against ``LocalMock`` in CI so the guide's code matches the client.
+"""
+
+from __future__ import annotations
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    mock = LocalMock()
+    mock.seed_collection_slug("sales_orders", id="sales_orders-id")
+    mock.seed(
+        "sales_orders-id",
+        [
+            {"order_id": "A-1", "amount": 120.0, "status": "open", "region": "EU"},
+            {"order_id": "A-2", "amount": 90.0, "status": "open", "region": "US"},
+            {"order_id": "A-3", "amount": 40.0, "status": "closed", "region": "EU"},
+        ],
+    )
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    from clappform import Clappform
+
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+
+    with cf:
+        # --8<-- [start:read]
+        orders = cf.data.collection("sales_orders")
+
+        # `where`, `fields` and `limit` are client-side sugar compiled into a
+        # $match / $project / $limit pipeline — the API never sees the kwargs.
+        df = orders.read(
+            where={"status": "open"},
+            fields=["order_id", "amount", "region"],
+            limit=1000,
+        )
+        # --8<-- [end:read]
+        assert len(df) == 2
+
+        # --8<-- [start:aggregate]
+        # For stages the sugar does not emit ($group, $sort, ...) pass a full
+        # pipeline. It is sent through untouched.
+        by_region = orders.aggregate(
+            [
+                {"$match": {"status": "open"}},
+                {"$group": {"_id": "$region", "total": {"$sum": "$amount"}}},
+            ]
+        )
+        # --8<-- [end:aggregate]
+        # The pipeline reaches the collection intact; LocalMock executes the
+        # $match it understands (2 open rows) and passes $group through without
+        # evaluating it, so this asserts the call round-trips, not that the mock
+        # reimplements $group.
+        assert len(by_region) == 2
+
+        # --8<-- [start:batches]
+        # Memory-bounded reads: one list of records per gRPC chunk, nothing
+        # fully materialised. Ask the server to cap each chunk with batch_size.
+        for batch in orders.iter_batches(where={"status": "open"}, batch_size=500):
+            handle(batch)
+        # --8<-- [end:batches]
+
+        # --8<-- [start:write]
+        # read -> mutate -> write-back. update() keys on _id by default, which
+        # read() keeps as a column, so the round-trip needs no `on=`.
+        df["amount"] = df["amount"] * 1.08
+        orders.update(df)
+
+        # insert brand-new rows
+        new_rows = df.head(0).assign(order_id=["A-9"], amount=[10.0], region=["EU"])
+        orders.append(new_rows)
+
+        # insert-or-update on a business key (no default — `on` is required)
+        orders.upsert(df, on="order_id")
+        # --8<-- [end:write]
+
+        # --8<-- [start:server-side]
+        # Mutate or delete without pulling rows through the client.
+        orders.replace_where({"status": "open"}, {"reviewed": True})
+        orders.delete(where={"status": "closed"})
+        # --8<-- [end:server-side]
+
+        # --8<-- [start:saved-query]
+        # A saved server-side query carries its own collection + pipeline.
+        revenue = cf.data.query("monthly-revenue-per-region")
+        revenue_df = revenue.read()
+        # --8<-- [end:saved-query]
+        # The saved query reads the same backing collection this snippet has
+        # been mutating, so it returns whatever rows now remain — assert it
+        # tracks the live store rather than a hard-coded count.
+        assert len(revenue_df) == len(transport.records("sales_orders-id"))
+        assert len(revenue_df) > 0
+
+
+def handle(batch: list) -> None:
+    """Stand-in for whatever the caller does with each batch."""
+    assert isinstance(batch, list)
+
+
+if __name__ == "__main__":
+    mock = build_mock()
+    mock.seed_query("monthly-revenue-per-region", collection="sales_orders-id")
+    run(mock)

--- a/docs/snippets/errors_and_retries.py
+++ b/docs/snippets/errors_and_retries.py
@@ -1,0 +1,59 @@
+"""Runnable source for the error-handling & retries guide snippets."""
+
+from __future__ import annotations
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    # One real collection is registered, so slug resolution runs — but "ghost"
+    # is not in the listing, so resolving it raises NotFoundError, the real path
+    # the snippet catches below.
+    mock = LocalMock()
+    mock.seed_collection_slug("real-collection", id="real-collection-id")
+    mock.seed("real-collection-id", [{"_id": "1", "value": 1}])
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    # --8<-- [start:retry-policy]
+    from clappform import DEFAULT_RETRIES, Clappform, RetryPolicy
+
+    # Retries are configured once on the client and applied by gRPC's built-in
+    # retry support. DEFAULT_RETRIES retries UNAVAILABLE with backoff; override
+    # per client when you need a different policy (or None to disable).
+    patient = RetryPolicy(max_attempts=6, initial_backoff="0.5s", max_backoff="10s")
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", retries=patient)
+    _ = (DEFAULT_RETRIES, cf)
+    # --8<-- [end:retry-policy]
+
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+
+    with cf:
+        # --8<-- [start:typed-errors]
+        from clappform import NotFoundError, TransientError
+
+        orders = cf.data.collection("ghost")  # no such slug in this tenant
+        try:
+            orders.read()
+        except NotFoundError as exc:
+            # Every error carries call context — method, cluster, location — so
+            # "which tenant on which cluster failed" is in the message.
+            handle_missing(exc)
+        except TransientError:
+            # Retries were configured and still exhausted; safe to retry the
+            # whole flow or surface a degraded state to the caller.
+            retry_later()
+        # --8<-- [end:typed-errors]
+
+
+def handle_missing(exc: Exception) -> None:
+    assert "location" in str(exc)
+
+
+def retry_later() -> None:  # pragma: no cover - not reached with the seeded mock
+    pass
+
+
+if __name__ == "__main__":
+    run(build_mock())

--- a/docs/snippets/multi_cluster.py
+++ b/docs/snippets/multi_cluster.py
@@ -1,0 +1,50 @@
+"""Runnable source for the multi-cluster / multi-tenant guide snippets."""
+
+from __future__ import annotations
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    mock = LocalMock()
+    mock.seed_collection_slug("orders", id="orders-id")
+    mock.seed("orders-id", [{"order_id": "A-1", "amount": 120.0, "region": "EU"}])
+    return mock
+
+
+def run(prod_transport: LocalMock, qa_transport: LocalMock) -> None:
+    # --8<-- [start:two-clusters]
+    from clappform import Clappform
+
+    # Two clusters, one process, nothing global. The `cluster` extension picks
+    # the endpoints (prod -> data.clappform.com, qa -> data-qa.clappform.com);
+    # `location` picks the tenant within them. Credentials are per client.
+    prod = Clappform(cluster="prod", location="acme", api_key="cf_live_prod_...")
+    qa = Clappform(cluster="qa", location="acme", api_key="cf_live_qa_...")
+    # --8<-- [end:two-clusters]
+
+    prod = Clappform(cluster="prod", location="acme", api_key="x", transport=prod_transport)
+    qa = Clappform(cluster="qa", location="acme", api_key="x", transport=qa_transport)
+
+    with prod, qa:
+        # --8<-- [start:cross-cluster]
+        # Pull from prod, mirror into qa by business key.
+        df = prod.data.collection("orders").read()
+        qa.data.collection("orders").upsert(df, on="order_id")
+        # --8<-- [end:cross-cluster]
+        assert len(df) == 1
+        # the row was mirrored into the qa cluster's store
+        assert len(qa_transport.records("orders-id")) == 1
+
+        # --8<-- [start:with-location]
+        # Same cluster, another tenant: with_location() clones cheaply and
+        # shares the underlying connections — only the tenant metadata differs.
+        beta = prod.with_location("beta")
+        beta_orders = beta.data.collection("orders").read()
+        # --8<-- [end:with-location]
+        # the clone shares prod's transport, so it reads prod's seeded row
+        assert len(beta_orders) == 1
+
+
+if __name__ == "__main__":
+    run(build_mock(), build_mock())

--- a/docs/snippets/quickstart.py
+++ b/docs/snippets/quickstart.py
@@ -1,0 +1,69 @@
+"""Runnable source for the quickstart snippets.
+
+Every fenced block in docs/quickstart.md is pulled from this file by the
+snippets extension, and this file runs end-to-end against ``LocalMock`` in the
+docs-test job — so the quickstart cannot document code that no longer works.
+The ``transport=LocalMock()`` argument is the only thing a reader drops to talk
+to a real cluster; the seeding below stands in for data that already lives in
+their tenant.
+"""
+
+from __future__ import annotations
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    """A mock seeded with the rows the quickstart reads back.
+
+    ``cf.data.collection("sales_orders")`` resolves the slug to a UUID first, so
+    the mock registers the slug->id mapping and seeds the store under that id.
+    """
+    mock = LocalMock()
+    mock.seed_collection_slug("sales_orders", id="sales_orders-id")
+    mock.seed(
+        "sales_orders-id",
+        [
+            {"order_id": "A-1", "amount": 120.0, "status": "open", "region": "EU"},
+            {"order_id": "A-2", "amount": 90.0, "status": "open", "region": "US"},
+            {"order_id": "A-3", "amount": 40.0, "status": "closed", "region": "EU"},
+        ],
+    )
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    # --8<-- [start:connect]
+    from clappform import Clappform
+
+    cf = Clappform(
+        location="acme",            # your tenant subdomain, sent on every call
+        cluster="prod",             # host extension; omit to discover it via DNS
+        api_key="cf_live_...",      # the only credential v6 ships
+    )
+    # --8<-- [end:connect]
+
+    # The docs example connects for real; the test swaps in a stubbed transport
+    # so the round-trip below runs with no network.
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+
+    with cf:
+        # --8<-- [start:roundtrip]
+        orders = cf.data.collection("sales_orders")
+
+        # read a filtered slice straight into a pandas DataFrame
+        df = orders.read(where={"status": "open"}, fields=["order_id", "amount", "region"])
+
+        # mutate with plain pandas
+        df["amount_eur"] = df["amount"] * 1.08
+
+        # write the changed rows back, matched on _id (kept by read())
+        orders.update(df)
+        # --8<-- [end:roundtrip]
+
+        assert len(df) == 2
+        assert "amount_eur" in df.columns
+
+
+if __name__ == "__main__":
+    run(build_mock())

--- a/docs/snippets/testing.py
+++ b/docs/snippets/testing.py
@@ -1,0 +1,66 @@
+"""Runnable source for the testing-with-LocalMock guide snippets."""
+
+from __future__ import annotations
+
+
+def run() -> None:
+    # --8<-- [start:seed]
+    from clappform import Clappform
+    from clappform.testing import LocalMock
+
+    # Seed the data plane, then point a client at the mock. No network, no keys
+    # that matter — the same JSON codec the real client uses drives the store.
+    # `collection("customers")` resolves the slug first, so register the mapping
+    # and seed the store under the resolved id.
+    mock = LocalMock()
+    mock.seed_collection_slug("customers", id="customers-id")
+    mock.seed(
+        "customers-id",
+        [
+            {"email": "a@example.com", "plan": "pro"},
+            {"email": "b@example.com", "plan": "free"},
+        ],
+    )
+    cf = Clappform(location="acme", cluster="prod", api_key="test", transport=mock)
+    # --8<-- [end:seed]
+
+    with cf:
+        # --8<-- [start:roundtrip]
+        customers = cf.data.collection("customers")
+
+        pro = customers.read(where={"plan": "pro"})
+        assert list(pro["email"]) == ["a@example.com"]
+
+        # writes mutate the store, so a follow-up read sees them
+        customers.replace_where({"plan": "free"}, {"plan": "pro"})
+        assert len(customers.read(where={"plan": "pro"})) == 2
+        # --8<-- [end:roundtrip]
+
+        # --8<-- [start:assert-calls]
+        # Every call is recorded for assertions.
+        assert any(
+            call.method.endswith("AggregateStream") for call in mock.calls
+        )
+        assert mock.calls[-1].location == "acme"
+        # --8<-- [end:assert-calls]
+
+    # --8<-- [start:stub]
+    # For RPCs without a built-in data handler, register a canned response with
+    # .on() keyed by the full gRPC method path — use the RPC's real response
+    # message so the stub matches what the server returns. An explicit stub
+    # always wins over a built-in handler.
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="af-123"),
+    )
+
+    with Clappform(location="acme", cluster="prod", api_key="test", transport=mock) as cf:
+        started = cf.client.actionflow.start(id="recalculate-dashboards")
+        assert started.uuid == "af-123"
+    # --8<-- [end:stub]
+
+
+if __name__ == "__main__":
+    run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,99 @@
+site_name: Clappform Python Client
+site_description: Python client for the Clappform gRPC APIs — DataFrame-first, multi-cluster, multi-tenant.
+site_url: https://clappform.readthedocs.io/
+repo_url: https://github.com/ClappFormOrg/clappform-python
+repo_name: ClappFormOrg/clappform-python
+copyright: Clappform B.V.
+
+# The reference is generated from the wrapper layer's docstrings, so the source
+# tree has to be importable when mkdocstrings resolves it.
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - content.code.annotate
+    - search.suggest
+    - toc.follow
+  palette:
+    # Light/dark toggle — the switch stamps the scheme, both are styled.
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+# Per-release version selector (§9): staggered cluster rollouts mean users must
+# read the docs for the version they are actually on. `mike` publishes one
+# versioned copy per release and RTD serves the selector from provider: mike.
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            # Render from the wrapper layer's docstrings only; the generated
+            # protobuf stubs are noise and are excluded from the nav entirely.
+            docstring_style: google
+            show_source: false
+            show_root_heading: true
+            show_root_full_path: false
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            filters: ["!^_"]
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  # Pulls runnable code out of docs/snippets/ into the guides. Those modules
+  # run against LocalMock in the docs-test job, so a snippet that stops working
+  # (or a bad include path) fails the build — the same guarantee tests give the
+  # code (§9).
+  - pymdownx.snippets:
+      base_path: [docs/snippets]
+      check_paths: true
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - How-to guides:
+      - DataFrame flows: guides/dataframes.md
+      - Multi-cluster & multi-tenant: guides/multi-cluster.md
+      - Error handling & retries: guides/errors-and-retries.md
+      - Testing with LocalMock: guides/testing.md
+  - Reference:
+      - Client: reference/client.md
+      - DataFrame surface: reference/dataframes.md
+      - Errors: reference/errors.md
+      - Testing: reference/testing.md
+      - API families: reference/api-families.md
+  - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,19 @@ dev = [
     "types-protobuf",
     "types-grpcio",
 ]
+# Docs toolchain (§9): MkDocs + Material, with mkdocstrings rendering the API
+# reference straight from the wrapper layer's docstrings, and the snippets
+# extension pulling runnable code out of docs/snippets/ so guide code can't
+# drift from what actually executes. mike drives the per-release version selector on
+# Read the Docs. Pinned to majors so a doc build is reproducible across
+# releases without dragging in a breaking theme change unnoticed.
+docs = [
+    "mkdocs>=1.6,<2",
+    "mkdocs-material>=9.5,<10",
+    "mkdocstrings[python]>=0.25,<1",
+    "pymdown-extensions>=10.0",
+    "mike>=2.1,<3",
+]
 
 [project.urls]
 Documentation = "https://clappform.readthedocs.io"
@@ -58,10 +71,18 @@ extend-exclude = [
     "src/clappform/gen",
     "src/clappform/services",
     "tests/servicegen_golden",
+    # MkDocs build output — a copy of the source tree, not source to lint.
+    "site",
 ]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+# Doc snippet sources deliberately re-import inside each function so that every
+# fenced block the guides include reads as standalone, copy-pasteable code.
+# That trips F811 (redefinition) — expected here, not a defect.
+"docs/snippets/*.py" = ["F811"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -1,0 +1,75 @@
+"""Every documented code snippet actually runs.
+
+The guides pull their fenced code out of ``docs/snippets/*.py`` via the mkdocs
+snippets extension, and each of those modules exposes a ``run()`` (or
+``build_mock()`` + ``run()``) entry point that exercises the snippet against
+``LocalMock``. This test drives every one of them, so a doc example that stops
+working fails the suite here as well as the docs build — the "docs can't rot"
+guarantee, enforced in CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SNIPPETS_DIR = Path(__file__).resolve().parent.parent / "docs" / "snippets"
+
+
+def _load(name: str):
+    """Import a snippet module by file path (docs/snippets is not on sys.path)."""
+    path = _SNIPPETS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"docs_snippets_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_snippets_directory_is_present() -> None:
+    """Guard against the snippet source being moved out from under the guides."""
+    assert _SNIPPETS_DIR.is_dir()
+    found = {p.stem for p in _SNIPPETS_DIR.glob("*.py")}
+    assert {
+        "quickstart",
+        "dataframes",
+        "multi_cluster",
+        "errors_and_retries",
+        "testing",
+    } <= found
+
+
+def test_quickstart_snippet_runs() -> None:
+    module = _load("quickstart")
+    module.run(module.build_mock())
+
+
+def test_dataframes_snippet_runs() -> None:
+    module = _load("dataframes")
+    mock = module.build_mock()
+    mock.seed_query("monthly-revenue-per-region", collection="sales_orders-id")
+    module.run(mock)
+
+
+def test_multi_cluster_snippet_runs() -> None:
+    module = _load("multi_cluster")
+    module.run(module.build_mock(), module.build_mock())
+
+
+def test_errors_and_retries_snippet_runs() -> None:
+    module = _load("errors_and_retries")
+    module.run(module.build_mock())
+
+
+def test_testing_snippet_runs() -> None:
+    module = _load("testing")
+    module.run()
+
+
+@pytest.mark.parametrize("name", ["quickstart", "dataframes", "multi_cluster"])
+def test_snippet_modules_import_clean(name: str) -> None:
+    """Importing a snippet module must have no side effects (no top-level run)."""
+    module = _load(name)
+    assert hasattr(module, "run")


### PR DESCRIPTION
## Summary

- Set up the MkDocs Material documentation pipeline: Material theme, mkdocstrings rendering the API reference from the wrapper layer's docstrings, and the snippets extension pulling runnable code out of `docs/snippets/`. The reference regenerates from the proto-sourced docstrings on every proto sync, so a new RPC appears in the docs in the same PR that adds it to the client.
- Wrote the hand-authored pages: quickstart, how-to guides (DataFrame flows, multi-cluster/multi-tenant, error handling & retries, testing with LocalMock), a per-family generated reference, and a changelog seeded with the 6.x line.
- Kept Read the Docs as the host via a `.readthedocs.yaml` (RTD supports MkDocs), with a `mike`-driven per-release version selector so users on staggered cluster rollouts read the docs for the version they run; the 4.x docs stay archived under their tag.
- Made the docs un-rottable: every guide code block is included from a module that runs against `LocalMock`, exercised by a test and by a CI `docs` job that also builds the site with `--strict`.

## Related issues

- Closes #48 — v6: docs — MkDocs Material on Read the Docs, generated reference, CI-tested snippets

## Tests

- `tests/test_docs_snippets.py` imports and runs each `docs/snippets/*.py` module against `LocalMock`, asserting the documented behaviour (row counts, mirrored writes, the typed `NotFoundError` path, a stubbed RPC round-trip) rather than just that the code imports.
- Local run: `ruff check .`, `mypy src/clappform tools`, `pytest -q --cov` (186 passed, 1 skipped, 97% coverage), and `mkdocs build --strict` all pass.

## Notes

- Design of record: `DESIGN.md` §9 (documentation) and §2 (repo layout).
- The CI-tested snippet sources live in `docs/snippets/` rather than `examples/`: `examples/` is gitignored as local scratch in this repo, so committed, version-controlled snippet sources belong in the docs tree. They are docs assets, not examples.
- The reference includes the full per-family RPC surface generated from the service wrappers' docstrings; the DataFrame guides lead with the ergonomic `collection()`/`query()` surface.
- Follow-up: the changelog currently carries a hand-written 6.x entry and the proto-version convention; wiring per-release entries (with proto diffs) into the release/publish workflow is a separate change.
- Follow-up: `LocalMock` does not evaluate `$group`/`$sort`, so the aggregation snippet asserts the pipeline round-trips (and the `$match` it does apply) rather than server-side grouping — noted inline in the snippet.