### PR TITLE
fix: target gRPC endpoints on 443 without an explicit port

### DIFF
--- a/src/clappform/_transport.py
+++ b/src/clappform/_transport.py
@@ -22,7 +22,6 @@ from clappform._errors import ConfigurationError, translate_rpc_error
 from clappform._runtime import CallKind
 
 BASE_DOMAIN = "clappform.com"
-DEFAULT_PORT = 443
 
 # Host prefix per API family, forming {prefix}{-extension}.clappform.com.
 # The authoriser serves under "auth", matching its family alias.
@@ -86,15 +85,18 @@ def resolve_endpoints(
     """Build the per-family endpoint map for a cluster extension.
 
     ``cluster`` is the host extension: ``""`` (or ``"prod"``) for the main
-    cluster, ``"qa"``-style values otherwise. Explicit ``overrides`` win per
-    family and may carry their own port.
+    cluster, ``"qa"``-style values otherwise. The supported (current) clusters
+    serve gRPC over TLS on 443, so the address is the bare host with no port —
+    gRPC defaults a secure channel to 443. Explicit ``overrides`` win per family
+    and may carry their own ``host:port`` (e.g. for an older cluster still on
+    ``:50051`` or a local dev endpoint).
     """
     extension = cluster.strip().lstrip("-").lower()
     if extension == "prod":
         extension = ""
     suffix = f"-{extension}" if extension else ""
     endpoints = {
-        family: f"{prefix}{suffix}.{BASE_DOMAIN}:{DEFAULT_PORT}"
+        family: f"{prefix}{suffix}.{BASE_DOMAIN}"
         for family, prefix in HOST_PREFIXES.items()
     }
     for family, address in (overrides or {}).items():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,16 +53,20 @@ def test_default_location_injected_and_per_call_override_wins() -> None:
 # --- endpoint resolution ------------------------------------------------------
 
 def test_endpoint_resolution_variants() -> None:
-    assert resolve_endpoints("qa")["data"] == "data-qa.clappform.com:443"
-    assert resolve_endpoints("")["data"] == "data.clappform.com:443"
-    assert resolve_endpoints("prod")["auth"] == "auth.clappform.com:443"
-    assert resolve_endpoints("QA-LTS")["client"] == "client-qa-lts.clappform.com:443"
+    # Supported clusters serve gRPC on 443, so the address is the bare host and
+    # gRPC defaults the secure channel to 443 — no explicit port is appended.
+    assert resolve_endpoints("qa")["data"] == "data-qa.clappform.com"
+    assert resolve_endpoints("")["data"] == "data.clappform.com"
+    assert resolve_endpoints("prod")["auth"] == "auth.clappform.com"
+    assert resolve_endpoints("QA-LTS")["client"] == "client-qa-lts.clappform.com"
 
 
 def test_endpoint_override_wins_and_unknown_family_rejected() -> None:
+    # An override may still carry an explicit host:port — e.g. an older cluster
+    # still on :50051, or a local dev endpoint.
     resolved = resolve_endpoints("qa", {"data": "10.0.0.5:50051"})
     assert resolved["data"] == "10.0.0.5:50051"
-    assert resolved["auth"] == "auth-qa.clappform.com:443"
+    assert resolved["auth"] == "auth-qa.clappform.com"
     with pytest.raises(ConfigurationError, match="unknown API family"):
         resolve_endpoints("qa", {"nbflow": "x:1"})
 


### PR DESCRIPTION
## Summary

- Endpoint resolution now targets the supported clusters' gRPC-on-443 setup: it emits the bare host (`data.clappform.com`, `auth-qa.clappform.com`, …) and lets gRPC default the secure channel to 443, instead of appending `:443`.
- Older clusters that still expose gRPC on `:50051` are out of scope; they remain reachable via an explicit `endpoints=` override, which continues to carry its own `host:port`.
- Removed the now-unused `DEFAULT_PORT` constant and updated the endpoint-resolution tests.

## Related issues

- Implements #43 — v6: confirm cluster endpoint details (gRPC port + extension list)

Resolves the gRPC-port question from #43 (443, no explicit port for supported clusters). The issue's other two items — the canonical list of the 6 cluster extensions and confirming every API family follows `{service}{-extension}.clappform.com` — are not addressed here, so #43 stays open.

## Tests

- `tests/test_client.py::test_endpoint_resolution_variants` — asserts the bare-host form for main/qa/qa-lts/prod.
- `tests/test_client.py::test_endpoint_override_wins_and_unknown_family_rejected` — an override may still carry an explicit `host:port` (e.g. `:50051`).
- Full suite: `ruff`, `mypy`, `pytest -q --cov` (186 passed, 1 skipped, 97%) pass locally.

## Notes

- This unblocks connecting to a live (newer) cluster — the address form now matches how those clusters actually serve gRPC.