### PR TITLE
chore: human-gated PyPI release pipeline via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+# Human-gated publish to PyPI. Nothing publishes automatically: a maintainer
+# cuts a GitHub Release (which carries the release notes, incl. the proto diff
+# of the sync), the build runs, and the upload then waits on the protected
+# `pypi` environment's required-reviewer approval before anything leaves CI.
+# Releases are timed by a human who knows the staggered 6-cluster rollout state.
+#
+# Auth is PyPI Trusted Publishing (OIDC) — no long-lived tokens live in the
+# repo. This requires a one-time setup on PyPI: add a trusted publisher for
+# this repository + workflow (`release.yml`) + environment (`pypi`), and create
+# a GitHub Environment named `pypi` with the maintainers as required reviewers.
+
+on:
+  release:
+    types: [published]
+  # Escape hatch for a re-run without cutting a new Release. Still gated by the
+  # same protected environment, so it cannot publish without approval.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & verify distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build tooling
+        run: python -m pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      # On a Release trigger, fail loudly if the tag and the packaged version
+      # disagree — a mismatched tag is the classic way a wrong version ships.
+      # Tag may be `v6.0.0a1` or `6.0.0a1`; compare on the normalized value.
+      - name: Check tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "package version: $PKG_VERSION   release tag: $TAG"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::Release tag ($TAG) does not match pyproject version ($PKG_VERSION). Bump the version or fix the tag."
+            exit 1
+          fi
+
+      - name: Verify metadata renders on PyPI
+        run: python -m twine check dist/*
+
+      - name: Upload distributions artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The protected environment is the human gate: the job pauses here until a
+    # required reviewer approves. Configure required reviewers on this
+    # environment in the repository settings.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/clappform/
+    permissions:
+      # OIDC token for trusted publishing. No API token is stored anywhere.
+      id-token: write
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publishing / OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No `password:` — OIDC trusted publishing authenticates via the
+        # id-token above. Defaults to the production index (pypi.org).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate lint typecheck test check build clean docs docs-serve docs-test
+.PHONY: generate lint typecheck test check build release-check clean docs docs-serve docs-test
 
 generate:
 	python tools/generate.py
@@ -16,6 +16,11 @@ check: lint typecheck test
 
 build:
 	python -m build
+
+# Build the distributions and validate their metadata — the same checks the
+# Release workflow runs before the gated PyPI publish. Does not upload.
+release-check: build
+	python -m twine check dist/*
 
 # Run the documented snippets against LocalMock, then build the site strictly
 # (a broken include, dead reference or nav typo fails the build).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing
+
+Publishing to PyPI is human-gated and uses **Trusted Publishing (OIDC)** — no
+API tokens are stored in the repo. The `Release` workflow (`.github/workflows/release.yml`)
+builds and verifies the distributions, then waits on the protected `pypi`
+environment's required-reviewer approval before uploading.
+
+## One-time setup
+
+1. **PyPI trusted publisher.** On the `clappform` project at
+   <https://pypi.org/manage/project/clappform/settings/publishing/>, add a
+   GitHub Actions trusted publisher:
+   - Owner: `ClappFormOrg`
+   - Repository: `clappform-python`
+   - Workflow: `release.yml`
+   - Environment: `pypi`
+2. **GitHub environment.** In the repository settings → Environments, create an
+   environment named `pypi` and add the release maintainers as **required
+   reviewers**. This is the approval gate the publish job pauses on.
+
+## Cutting a release
+
+1. Land everything for the release on `Major/6`, then promote to the default
+   branch per the branch flow.
+2. Bump `version` in `pyproject.toml` (pre-releases use PEP 440 suffixes, e.g.
+   `6.0.0a1`, `6.0.0rc1`). Commit.
+3. Tag and publish a **GitHub Release** whose tag matches the version
+   (`v6.0.0a1` or `6.0.0a1`). Put the release notes — including the proto diff
+   of the sync — in the release body.
+4. The `Release` workflow runs: it builds the sdist + wheel, fails if the tag
+   and packaged version disagree, and validates metadata with `twine check`.
+5. The `publish` job then pauses on the `pypi` environment. A required reviewer
+   approves, and only then does the upload run.
+
+Pre-releases (`aN`/`bN`/`rcN`) are not installed by a plain `pip install
+clappform`; users opt in with `pip install --pre clappform` or a pinned
+`clappform==6.0.0a1`.
+
+## Verifying locally before you tag
+
+```bash
+make release-check   # build sdist+wheel and run `twine check` (no upload)
+```
+
+Inspect `dist/`, or install the wheel into a throwaway venv and import it, to
+confirm the artifact before cutting the Release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dev = [
     "grpcio-tools>=1.60,<2",
     "types-protobuf",
     "types-grpcio",
+    # Release tooling: build the sdist/wheel and validate metadata locally, the
+    # same steps the Release workflow runs before the gated publish.
+    "build>=1.2",
+    "twine>=5.0",
 ]
 # Docs toolchain (§9): MkDocs + Material, with mkdocstrings rendering the API
 # reference straight from the wrapper layer's docstrings, and the snippets


### PR DESCRIPTION
## Summary

- Add a `Release` workflow that publishes to **production PyPI** when a GitHub Release is published (with a `workflow_dispatch` escape hatch).
- Auth is **PyPI Trusted Publishing (OIDC)** — no API tokens stored in the repo.
- The workflow builds the sdist + wheel, **fails if the release tag and the packaged version disagree**, and validates metadata with `twine check` before publishing.
- The upload runs in a **protected `pypi` environment**, so it pauses for required-reviewer approval — releases stay timed by a human who knows the staggered cluster rollout state; nothing publishes automatically.
- Declare `build`/`twine` in the `dev` extra, add a `make release-check` target (build + `twine check`, no upload), and document the one-time setup + release steps in `RELEASING.md`.

## Related issues

- Implements #47 — v6: release pipeline — human-gated publish, trusted publishing, changelog

Delivers the human-gated trusted-publishing pipeline and the "release notes carry the proto diff" convention. The **5.x-line deprecation notice on PyPI** and the docs-publish hookup from #47 are not included here, so #47 stays open.

## Required manual setup (console-only, cannot be done in-repo)

Before the first release, a maintainer must:
1. Add a **PyPI trusted publisher** on the `clappform` project — repo `ClappFormOrg/clappform-python`, workflow `release.yml`, environment `pypi`.
2. Create a GitHub **Environment named `pypi`** with the release maintainers as required reviewers.

Steps are written up in `RELEASING.md`.

## Tests / verification

- `release.yml` and `ci.yml` parse as valid YAML; the tag/version extraction command runs against `pyproject.toml`.
- Built the current `6.0.0a0` sdist + wheel locally: `twine check` passes both, the wheel contains the generated stubs and the public `clappform.testing` surface, and excludes `examples/`/`docs/`; a clean-venv install imports and round-trips a DataFrame read through `LocalMock`.
- `ruff` clean.

## Notes

- Targets production PyPI (pypi.org) as requested. The version stays `6.0.0a0` on this branch; the actual published version is set by the release tag when a maintainer cuts the Release (pre-releases need `pip install --pre`).
- No publish is triggered by this PR — the workflow only runs on a published Release (or manual dispatch) and still waits on the environment approval gate.