### PR TITLE
chore: add TestPyPI dry-run target to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,21 +2,36 @@ name: Release
 
 # Human-gated publish to PyPI. Nothing publishes automatically: a maintainer
 # cuts a GitHub Release (which carries the release notes, incl. the proto diff
-# of the sync), the build runs, and the upload then waits on the protected
-# `pypi` environment's required-reviewer approval before anything leaves CI.
-# Releases are timed by a human who knows the staggered 6-cluster rollout state.
+# of the sync) or dispatches this workflow, the build runs, and the upload then
+# waits on the target environment's required-reviewer approval before anything
+# leaves CI. Releases are timed by a human who knows the staggered 6-cluster
+# rollout state.
+#
+# Two targets:
+#   * A published GitHub Release always goes to production PyPI.
+#   * A manual dispatch defaults to TestPyPI (a throwaway index) so the OIDC +
+#     build + upload plumbing can be validated end-to-end without burning a real
+#     version on the public `clappform` project; choose `pypi` to dispatch a
+#     production publish instead.
 #
 # Auth is PyPI Trusted Publishing (OIDC) — no long-lived tokens live in the
-# repo. This requires a one-time setup on PyPI: add a trusted publisher for
-# this repository + workflow (`release.yml`) + environment (`pypi`), and create
-# a GitHub Environment named `pypi` with the maintainers as required reviewers.
+# repo. One-time setup: add a trusted publisher on BOTH indexes you use
+# (pypi.org and/or test.pypi.org) for this repository + workflow (`release.yml`)
+# + the matching environment name (`pypi` / `testpypi`), and create GitHub
+# Environments `pypi` and `testpypi` with maintainers as required reviewers.
 
 on:
   release:
     types: [published]
-  # Escape hatch for a re-run without cutting a new Release. Still gated by the
-  # same protected environment, so it cannot publish without approval.
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        default: testpypi
+        options:
+          - testpypi
+          - pypi
 
 permissions:
   contents: read
@@ -64,15 +79,15 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish to PyPI
+    name: Publish
     needs: build
     runs-on: ubuntu-latest
-    # The protected environment is the human gate: the job pauses here until a
-    # required reviewer approves. Configure required reviewers on this
-    # environment in the repository settings.
+    # A published Release always targets production; a manual dispatch uses the
+    # chosen `target` input (default testpypi). The environment name is derived
+    # from that so each index keeps its own protected approval gate.
     environment:
-      name: pypi
-      url: https://pypi.org/project/clappform/
+      name: ${{ (github.event_name == 'release' || inputs.target == 'pypi') && 'pypi' || 'testpypi' }}
+      url: ${{ (github.event_name == 'release' || inputs.target == 'pypi') && 'https://pypi.org/project/clappform/' || 'https://test.pypi.org/project/clappform/' }}
     permissions:
       # OIDC token for trusted publishing. No API token is stored anywhere.
       id-token: write
@@ -83,7 +98,14 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish to PyPI (Trusted Publishing / OIDC)
+      - name: Publish to production PyPI (Trusted Publishing / OIDC)
+        if: github.event_name == 'release' || inputs.target == 'pypi'
         uses: pypa/gh-action-pypi-publish@release/v1
         # No `password:` — OIDC trusted publishing authenticates via the
         # id-token above. Defaults to the production index (pypi.org).
+
+      - name: Publish to TestPyPI (Trusted Publishing / OIDC)
+        if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,21 +2,55 @@
 
 Publishing to PyPI is human-gated and uses **Trusted Publishing (OIDC)** — no
 API tokens are stored in the repo. The `Release` workflow (`.github/workflows/release.yml`)
-builds and verifies the distributions, then waits on the protected `pypi`
-environment's required-reviewer approval before uploading.
+builds and verifies the distributions, then waits on the target environment's
+required-reviewer approval before uploading.
+
+The workflow has two targets:
+
+- A **published GitHub Release** always uploads to **production PyPI**
+  (`pypi.org`), gated by the `pypi` environment.
+- A **manual dispatch** (Actions → Release → Run workflow) defaults to
+  **TestPyPI** (`test.pypi.org`), gated by the `testpypi` environment — use it
+  to validate the OIDC + build + upload flow end-to-end without burning a real
+  version on the public project. The dispatch also offers `pypi` as a target
+  for a production publish without cutting a Release.
 
 ## One-time setup
 
-1. **PyPI trusted publisher.** On the `clappform` project at
-   <https://pypi.org/manage/project/clappform/settings/publishing/>, add a
-   GitHub Actions trusted publisher:
+Set up whichever index(es) you will publish to. TestPyPI and PyPI are
+completely separate accounts and projects.
+
+1. **Trusted publishers.** Add a GitHub Actions trusted publisher on each index:
+   - Production: `clappform` at
+     <https://pypi.org/manage/project/clappform/settings/publishing/> with
+     **Environment: `pypi`**.
+   - TestPyPI: register on <https://test.pypi.org> (the `clappform` name there is
+     independent; claim it via the pending-publisher flow if it does not exist
+     yet) with **Environment: `testpypi`**.
+
+   All other fields are identical on both:
    - Owner: `ClappFormOrg`
    - Repository: `clappform-python`
    - Workflow: `release.yml`
-   - Environment: `pypi`
-2. **GitHub environment.** In the repository settings → Environments, create an
-   environment named `pypi` and add the release maintainers as **required
-   reviewers**. This is the approval gate the publish job pauses on.
+2. **GitHub environments.** In the repository settings → Environments, create
+   environments named `pypi` and `testpypi`, each with the release maintainers
+   as **required reviewers**. These are the approval gates the publish job
+   pauses on.
+
+## Dry-run to TestPyPI first (recommended)
+
+Before the first production release, validate the whole path without burning a
+version:
+
+1. Merge this workflow to the branch you will dispatch from (workflows run from
+   the branch they live on).
+2. Actions → **Release** → **Run workflow** → leave `target` as `testpypi` → Run.
+3. The `build` job runs; the `publish` job pauses on the `testpypi` environment
+   → approve it.
+4. Confirm the upload at <https://test.pypi.org/project/clappform/> and, if you
+   want, install it: `pip install --index-url https://test.pypi.org/simple/
+   --extra-index-url https://pypi.org/simple/ --pre clappform` (the extra index
+   lets dependencies resolve from real PyPI).
 
 ## Cutting a release
 


### PR DESCRIPTION
## Summary

- Add a `workflow_dispatch` `target` input (default **testpypi**) to the Release workflow, so the OIDC + build + upload path can be validated end-to-end on `test.pypi.org` without burning a real version on the public project.
- A published **GitHub Release still always goes to production PyPI**; the manual dispatch can also target `pypi` for a production publish without cutting a Release.
- Each index uses its own protected environment (`pypi` / `testpypi`), so approvals stay separate.
- Document the second trusted publisher, the `testpypi` environment, and the dry-run steps in `RELEASING.md`.

## Related issues

- Implements #47 — release pipeline (adds the TestPyPI dry-run path on top of the trusted-publishing pipeline landed in #68).

## How the target is chosen

- `release: published` → production PyPI (`pypi` environment).
- `workflow_dispatch` with `target=testpypi` (default) → TestPyPI (`testpypi` environment).
- `workflow_dispatch` with `target=pypi` → production PyPI.

## Extra manual setup for the dry-run

Beyond the production setup already documented, to use the TestPyPI path a maintainer must:
1. Register a trusted publisher on **test.pypi.org** (independent account/project) — repo `ClappFormOrg/clappform-python`, workflow `release.yml`, environment `testpypi`.
2. Create a GitHub **`testpypi` environment** with required reviewers.

## Verification

- `release.yml` parses as valid YAML; the target-selection expression resolves to `pypi` on a Release and to the chosen input on dispatch (undefined `inputs.target` on a Release event evaluates empty, so the release path still selects production).
- No publish is triggered by this PR.