### PR TITLE
chore: bump release workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
     name: Build & verify distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -72,7 +72,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload distributions artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/
@@ -93,7 +93,7 @@ jobs:
       id-token: write
     steps:
       - name: Download built distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

- Bump the Release workflow's Node-based actions off the deprecated Node 20 runtime: `actions/checkout@v4→v5`, `actions/setup-python@v5→v6`, `actions/upload-artifact@v4→v5`, and `actions/download-artifact@v4→v5`.

## Why

The TestPyPI dry-run run surfaced a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4.

Bumping to the Node 24 majors clears it. `download-artifact` is bumped in the same commit so the upload/download pair stays on the matched v5 format. `pypa/gh-action-pypi-publish` is a container action and is unaffected.

## Scope

Only `release.yml` is touched, as requested. `ci.yml` uses the same actions and has the same warning, but is intentionally left out of this PR.

## Verification

- `release.yml` parses as valid YAML; only the four `uses:` versions changed.
- No behavioural change to the build/publish logic or the environment gates.