### PR TITLE
fix: reject infinite floats and empty-filter deletes

### DIFF
--- a/src/clappform/_codec.py
+++ b/src/clappform/_codec.py
@@ -68,6 +68,15 @@ def _normalise_value(value: Any) -> Any:
         # to themselves. isnan rejects non-floats, so guard on float first.
         if math.isnan(value):
             return None
+        # Infinities have no JSON representation — json.dumps would emit the
+        # non-standard ``Infinity`` token, which the server cannot parse. Fail
+        # loudly so an infinity (almost always a computation bug) is surfaced
+        # here rather than silently corrupting the payload on the wire.
+        if math.isinf(value):
+            raise ValueError(
+                "cannot encode infinite float value; JSON has no representation "
+                "for inf/-inf — clean the data before writing"
+            )
         return value
     if isinstance(value, (datetime, date)):
         return value.isoformat()

--- a/src/clappform/dataframes.py
+++ b/src/clappform/dataframes.py
@@ -470,6 +470,15 @@ class CollectionHandle(_AggregateReader):
         """
         if (where is None) == (oids is None):
             raise ValueError("pass exactly one of where= or oids=")
+        if where is not None and not where:
+            # An empty filter matches every document. Deleting the whole
+            # collection must be explicit, so refuse it here and point at the
+            # deliberate full-wipe method rather than let an empty where=
+            # silently clear everything.
+            raise ValueError(
+                "where={} matches every document; use clear() to wipe the "
+                "whole collection explicitly"
+            )
         if oids is not None:
             self._client.data.delete.delete_many_by_oids(
                 collection=self.collection_id,

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -171,3 +171,17 @@ def test_float_nan_helper_is_json_null_not_string() -> None:
     # json.dumps would otherwise emit for an unguarded float.
     data = _codec.records_to_bytes([{"x": math.nan}])
     assert b"NaN" not in data
+
+
+@pytest.mark.parametrize("value", [math.inf, -math.inf, float("inf"), float("-inf")])
+def test_infinite_floats_are_rejected(value: float) -> None:
+    # JSON has no representation for inf/-inf; json.dumps would emit the
+    # non-standard "Infinity" token the server cannot parse. Encoding must fail
+    # loudly rather than corrupt the payload.
+    with pytest.raises(ValueError, match="infinite float"):
+        _codec.records_to_bytes([{"x": value}])
+
+
+def test_infinite_float_nested_in_container_is_rejected() -> None:
+    with pytest.raises(ValueError, match="infinite float"):
+        _codec.records_to_bytes([{"nested": {"deep": [math.inf]}}])

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -226,6 +226,17 @@ def test_delete_requires_exactly_one_selector(cf) -> None:
         col.delete(where={"x": 1}, oids=["a"])
 
 
+def test_delete_with_empty_where_is_refused_and_leaves_data(cf) -> None:
+    # An empty filter matches everything; deleting the whole collection must be
+    # explicit via clear(), never a side effect of an empty where=.
+    client, mock = cf
+    _seed_orders(mock)
+    col = client.data.collection(CID)
+    with pytest.raises(ValueError, match="use clear"):
+        col.delete(where={})
+    assert len(mock.records(CID)) == 3  # nothing was deleted
+
+
 def test_clear_empties_collection(cf) -> None:
     client, mock = cf
     _seed_orders(mock)


### PR DESCRIPTION
## Summary

Two defects surfaced by the test-gap review, each with a regression test:

- **Codec — infinite floats.** `inf`/`-inf` slipped past the NaN guard in `_normalise_value` and reached `json.dumps`, which emits the non-standard `Infinity` token the server can't parse. Now raises `ValueError` on encode (fail loud — an infinity is almost always a computation bug), consistent with how NaN is already handled. Covers nested containers.
- **Data — empty-filter delete.** `delete(where={})` passed the exactly-one-selector guard (an empty dict is not `None`) and reached `delete_many_by_query` with a filter matching every document — silently wiping the collection, the exact accident the docstring says `clear()` exists to prevent. Now refuses a falsy `where=` with a `ValueError` pointing at `clear()`.

## Tests

- `tests/test_codec.py`: `inf`/`-inf` (and nested) rejected on encode.
- `tests/test_dataframes.py`: `delete(where={})` raises and leaves all rows intact.
- Full suite: ruff, mypy, `pytest -q --cov` (192 passed, 1 skipped, 97%) all pass locally.

## Notes

- Behaviour choices confirmed with the maintainer: `inf` → raise (not coerce to null); empty `where` → reject.
- Both are behaviour changes at the client edge (encode-time / pre-flight), no wire or API-shape change.
- Remaining items from the test-gap review (TLS-path coverage, resolver pagination, E2E auth/lifecycle, etc.) are documented separately and not in this PR.