### PR TITLE
test: harden transport/client/discovery coverage to 99%

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,3 +180,29 @@ def test_channel_for_rejected_on_custom_transport() -> None:
     cf, _ = make_client()
     with pytest.raises(ConfigurationError, match="custom transport"):
         cf.channel_for("data")
+
+
+def test_channel_for_returns_live_channel_on_owned_transport() -> None:
+    # With an owned GrpcTransport, channel_for exposes the real grpc.Channel and
+    # returns the same cached instance on repeat calls.
+    import grpc
+
+    cf = Clappform("acme", "qa", api_key="k", endpoints={"data": "127.0.0.1:1"}, insecure=True)
+    try:
+        channel = cf.channel_for("data")
+        assert isinstance(channel, grpc.Channel)
+        assert cf.channel_for("data") is channel
+    finally:
+        cf.close()
+
+
+def test_with_location_clone_close_does_not_break_parent() -> None:
+    # A shared-transport clone is not the transport owner; closing it must be a
+    # no-op that leaves the parent (and its channels) usable — the multi-tenant
+    # safety invariant.
+    cf, transport = make_client(cluster="qa")
+    clone = cf.with_location("umbrella")
+    clone.close()  # clone does not own the transport
+    # parent still serves calls after the clone is closed
+    cf.data.insert.insert_single(collection="orders")
+    assert transport.calls[-1][1] == "acme"

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -303,3 +303,34 @@ def test_collection_handle_repr(cf) -> None:
     assert "CollectionHandle" in repr(client.data.collection(CID))
     assert isinstance(client.data.collection(CID), CollectionHandle)
     assert isinstance(client.data.query(CID), QueryHandle)
+
+
+QID = "8f14e45f-ceea-467f-a34e-95b7f7f7a9d1"
+
+
+def test_query_handle_fetch_returns_readresult(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    mock.seed_query(QID, collection=CID, id=QID)
+    result = client.data.query(QID).fetch()
+    assert isinstance(result, ReadResult)
+    assert len(list(result)) == 3
+
+
+def test_query_handle_iter_batches_streams_per_chunk(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    mock.seed_query(QID, collection=CID, id=QID)
+    batches = list(client.data.query(QID).iter_batches(batch_size=2))
+    # 3 seeded rows, batch_size=2 -> [2, 1]
+    assert [len(b) for b in batches] == [2, 1]
+
+
+def test_query_handle_repr_shows_resolved_id_after_use(cf) -> None:
+    client, mock = cf
+    _seed_orders(mock)
+    mock.seed_query(QID, collection=CID, id=QID)
+    q = client.data.query(QID)
+    assert "->" not in repr(q)  # unresolved before use
+    q.read()
+    assert f"-> {QID}" in repr(q)  # resolved id shown after use

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -73,3 +73,37 @@ def test_errors_are_catchable_as_clappform_error() -> None:
     resolver = lambda host: "wrong.example.com"  # noqa: E731
     with pytest.raises(ClappformError):
         discover_cluster("acme", resolver=resolver)
+
+
+def test_default_resolver_uses_socket_gethostbyname_ex(monkeypatch) -> None:
+    # With no resolver= injected, discovery falls back to the real socket
+    # lookup and takes the canonical name (index 0 of the returned tuple).
+    seen: list[str] = []
+
+    def fake_gethostbyname_ex(host: str):
+        seen.append(host)
+        return ("bigip-qa-lts.clappform.com", ["acme.clappform.com"], ["10.0.0.1"])
+
+    monkeypatch.setattr(socket, "gethostbyname_ex", fake_gethostbyname_ex)
+    assert discover_cluster("acme") == "qa-lts"
+    assert seen == ["acme.clappform.com"]
+
+
+def test_bigip_without_extension_but_trailing_hyphen_is_rejected() -> None:
+    # `bigip-` with an empty extension does not match the [a-z0-9-]+ group.
+    resolver = lambda host: "bigip-.clappform.com"  # noqa: E731
+    with pytest.raises(ConfigurationError, match="does not match"):
+        discover_cluster("acme", resolver=resolver)
+
+
+def test_loose_bigip_prefix_is_not_matched() -> None:
+    # `bigipextra` must not be treated as bigip + extension; only a `.` or `-`
+    # separator after `bigip` is valid.
+    resolver = lambda host: "bigipextra.clappform.com"  # noqa: E731
+    with pytest.raises(ConfigurationError, match="does not match"):
+        discover_cluster("acme", resolver=resolver)
+
+
+def test_extension_with_digits_is_extracted() -> None:
+    resolver = lambda host: "bigip-v2.clappform.com"  # noqa: E731
+    assert discover_cluster("acme", resolver=resolver) == "v2"

--- a/tests/test_transport_unit.py
+++ b/tests/test_transport_unit.py
@@ -1,0 +1,176 @@
+"""Transport internals exercised directly (no wire).
+
+`test_transport_grpc.py` drives the full stack over a real loopback channel;
+this file covers the branches that end-to-end tests can't easily reach: the
+production TLS channel construction, the channel_for guard/cache paths, the
+`_options`/`_metadata` composition, and `family_of_method` parsing.
+"""
+
+from __future__ import annotations
+
+import grpc
+import pytest
+
+from clappform import ApiKey, ConfigurationError
+from clappform._transport import (
+    DEFAULT_RETRIES,
+    GrpcTransport,
+    RetryPolicy,
+    family_of_method,
+)
+
+
+def _transport(**overrides) -> GrpcTransport:
+    defaults = dict(
+        endpoints={"data": "data.clappform.com"},
+        credentials=ApiKey("k"),
+        cluster="",
+    )
+    defaults.update(overrides)
+    return GrpcTransport(**defaults)  # type: ignore[arg-type]
+
+
+# --- family_of_method --------------------------------------------------------
+
+def test_family_of_method_derives_family() -> None:
+    assert (
+        family_of_method("/clappform.data.v1.insert.InsertManagement/InsertMany")
+        == "data"
+    )
+
+
+def test_family_of_method_maps_authoriser_to_auth() -> None:
+    # The authoriser package is served under the `auth` family alias.
+    assert family_of_method("/clappform.authoriser.v1.apikey.APIKeyManagement/Generate") == "auth"
+
+
+@pytest.mark.parametrize("method", ["/foo.bar/Baz", "/clappform/X", "NoSlashes"])
+def test_family_of_method_rejects_malformed(method: str) -> None:
+    with pytest.raises(ConfigurationError, match="cannot derive API family"):
+        family_of_method(method)
+
+
+# --- channel_for -------------------------------------------------------------
+
+def test_channel_for_uses_secure_channel_by_default(monkeypatch) -> None:
+    # Production default is insecure=False; the secure/TLS path must be taken.
+    # (Every wire test uses insecure=True, so this branch is otherwise unrun.)
+    calls: dict[str, object] = {}
+
+    def fake_secure(address, creds, options=None):
+        calls["address"] = address
+        calls["creds"] = creds
+        calls["options"] = options
+        return "SECURE_CHANNEL"
+
+    monkeypatch.setattr(grpc, "secure_channel", fake_secure)
+    monkeypatch.setattr(grpc, "ssl_channel_credentials", lambda: "SSL_CREDS")
+
+    transport = _transport(insecure=False)
+    channel = transport.channel_for("data")
+
+    assert channel == "SECURE_CHANNEL"
+    assert calls["address"] == "data.clappform.com"
+    assert calls["creds"] == "SSL_CREDS"
+
+
+def test_channel_for_uses_insecure_channel_when_requested(monkeypatch) -> None:
+    monkeypatch.setattr(grpc, "insecure_channel", lambda address, options=None: "INSECURE")
+    transport = _transport(insecure=True)
+    assert transport.channel_for("data") == "INSECURE"
+
+
+def test_channel_for_caches_one_channel_per_address(monkeypatch) -> None:
+    made: list[str] = []
+    monkeypatch.setattr(
+        grpc, "insecure_channel", lambda address, options=None: made.append(address) or object()
+    )
+    transport = _transport(insecure=True)
+    first = transport.channel_for("data")
+    second = transport.channel_for("data")
+    assert first is second  # cache hit, not rebuilt
+    assert made == ["data.clappform.com"]  # channel built exactly once
+
+
+def test_channel_for_unknown_family_raises(monkeypatch) -> None:
+    monkeypatch.setattr(grpc, "insecure_channel", lambda address, options=None: object())
+    transport = _transport(insecure=True)  # only "data" is configured
+    with pytest.raises(ConfigurationError, match="no endpoint configured"):
+        transport.channel_for("notifier")
+
+
+def test_channel_for_after_close_raises(monkeypatch) -> None:
+    monkeypatch.setattr(grpc, "insecure_channel", lambda address, options=None: object())
+    transport = _transport(insecure=True)
+    transport.close()
+    with pytest.raises(ConfigurationError, match="client is closed"):
+        transport.channel_for("data")
+
+
+def test_close_is_idempotent_and_tears_down_channels(monkeypatch) -> None:
+    class FakeChannel:
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def close(self) -> None:
+            self.closed += 1
+
+    channels: list[FakeChannel] = []
+    monkeypatch.setattr(
+        grpc,
+        "insecure_channel",
+        lambda address, options=None: channels.append(FakeChannel()) or channels[-1],
+    )
+    transport = _transport(insecure=True)
+    ch = transport.channel_for("data")
+    transport.close()
+    transport.close()  # second close must not raise
+    assert ch.closed == 1
+
+
+# --- _options ----------------------------------------------------------------
+
+def test_options_include_custom_channel_options() -> None:
+    transport = _transport(channel_options=[("grpc.custom_opt", 7)])
+    assert ("grpc.custom_opt", 7) in transport._options()
+
+
+def test_options_include_retries_by_default() -> None:
+    transport = _transport(retries=DEFAULT_RETRIES)
+    keys = [k for k, _ in transport._options()]
+    assert "grpc.enable_retries" in keys
+    assert "grpc.service_config" in keys
+
+
+def test_options_omit_retries_when_disabled() -> None:
+    transport = _transport(retries=None)
+    keys = [k for k, _ in transport._options()]
+    assert "grpc.enable_retries" not in keys
+
+
+# --- _metadata ---------------------------------------------------------------
+
+def test_metadata_includes_credentials_and_location() -> None:
+    transport = _transport()
+    md = dict(transport._metadata("acme", None))
+    assert md["x-api-key"] == "k"
+    assert md["location"] == "acme"
+
+
+def test_metadata_omits_location_header_when_none() -> None:
+    transport = _transport()
+    md = dict(transport._metadata(None, None))
+    assert "location" not in md
+
+
+def test_metadata_appends_per_call_extra() -> None:
+    transport = _transport()
+    md = transport._metadata("acme", (("x-trace-id", "abc"),))
+    assert ("x-trace-id", "abc") in md
+
+
+def test_retry_policy_service_config_defaults() -> None:
+    # DEFAULT_RETRIES values flow into the gRPC service config JSON.
+    cfg = RetryPolicy().service_config()
+    assert '"maxAttempts": 4' in cfg
+    assert "UNAVAILABLE" in cfg


### PR DESCRIPTION
## Summary

Close the high-value unit-coverage gaps from the test-gap review, taking the hand-written surface from **97.09% → 99%**. No production code changes — tests only.

- **Transport internals** (`tests/test_transport_unit.py`, new): the production **TLS `secure_channel` path** (every wire test uses `insecure=True`, so it was never constructed), `channel_for` unknown-family + use-after-`close()` guards, channel caching, `close()` idempotency/teardown, `_options` merge + retries on/off, `_metadata` composition, and `family_of_method` parsing (incl. the `authoriser→auth` alias and malformed-method rejection).
- **Discovery**: the default `socket.gethostbyname_ex` resolver path (all tests previously injected a stub), plus bigip-regex boundaries (empty extension, loose prefix, digit-bearing extension).
- **Client**: `channel_for` success on an owned `GrpcTransport`, and the shared-transport `with_location` clone `close()` being a no-op that leaves the parent usable (multi-tenant safety invariant).
- **Query handle**: `fetch()` / `iter_batches()` (only `read()` was covered) and the resolved-id repr.

## Coverage

`_transport.py` and `_discovery.py` now fully covered; `_client.py` and `dataframes.py` at 99%. The residual misses are deliberate and left alone: `_client.py:196` (defensive `if close is not None` false arm), `dataframes.py:173` (zero-chunk `StopIteration`, unreachable via the mock), and `_local_mock.py` (the test double itself).

## Tests

- +27 tests; full suite **219 passed, 1 skipped, 99%**. `ruff` + `mypy` clean.

## Notes

- Larger end-to-end gaps (auth/notifier E2E, write-lifecycle-over-the-wire, concurrency, real multi-cluster) are tracked separately as a follow-up issue.