### PR TITLE
docs: usage examples for aggregates, writes, actionflows, listings and app transfer

### DIFF
--- a/docs/guides/actionflows-and-listings.md
+++ b/docs/guides/actionflows-and-listings.md
@@ -1,0 +1,73 @@
+# Actionflows & listings
+
+The [DataFrame flows](dataframes.md) cover reading and writing a collection's
+rows. The operations here live on `cf.client` instead — starting an actionflow,
+and listing the objects in a tenant: collections, apps, saved queries and
+cronjobs. They're the everyday non-data-plane calls.
+
+Every listing follows the same shape — a `get_all()` that returns one page plus
+pagination, and an `iter_get_all()` that auto-paginates — so once you've seen
+one you've seen them all.
+
+## Start an actionflow
+
+Trigger an actionflow by id. The response carries the run's `uuid`, so you can
+correlate the run with the tasks it spawns or surface it to a caller. Pass
+`user_id=` to attribute the run, or `custom_keys=` (JSON bytes) to hand it
+start parameters.
+
+```python
+--8<-- "client_operations.py:start-actionflow"
+```
+
+## List actionflows
+
+`iter_get_all()` yields every actionflow across all pages — you never manage
+`page` yourself. When you want the pagination metadata (or just the first page),
+call `get_all()` directly.
+
+```python
+--8<-- "client_operations.py:list-actionflows"
+```
+
+`cf.client.actionflow_task` mirrors this exactly (`get_all()` / `iter_get_all()`
+/ `get(id=...)`) for the tasks an actionflow is composed of.
+
+## Read all collections
+
+Listing collections is how you discover what's there to read. Each `Collection`
+carries its `slug` and `id` — the same id `cf.data.collection(slug)` resolves to
+under the hood — so this is the bridge from "what collections exist" to the
+DataFrame flows.
+
+```python
+--8<-- "client_operations.py:list-collections"
+```
+
+## List apps, saved queries and cronjobs
+
+The same `get_all()` / `iter_get_all()` pair lists the rest of the tenant's
+objects. Anything on `cf.client` with a listing follows this shape.
+
+```python
+--8<-- "client_operations.py:list-others"
+```
+
+## Everything else on `cf.client`
+
+`cf.client` wraps one method per RPC across the whole client API — beyond the
+above it also carries `page`, `widget`, `group`, `row`, `collection_rule`,
+`process`, `secret` and more, each with the same `get_all` / `get` / `create` /
+`update` / `delete` surface where the RPC exists. Cronjobs additionally expose
+`start(id=...)` / `stop(id=...)` (and `start_all()` / `stop_all()`); `transfer`
+moves a whole app between instances (see
+[Moving a whole app between instances](multi-cluster.md#moving-a-whole-app-between-instances)).
+The [API families reference](../reference/api-families.md) is the generated,
+exhaustive list.
+
+!!! note "Stubbing these in your own tests"
+    None of these are data-plane RPCs, so
+    [`LocalMock`][clappform.testing.LocalMock] has no built-in handler — the
+    snippet above backs each with an explicit `.on(method_path, response)` stub.
+    That's the same pattern you use to test your own code that calls them; see
+    [Testing with LocalMock](testing.md#stub-any-other-rpc).

--- a/docs/guides/dataframes.md
+++ b/docs/guides/dataframes.md
@@ -24,11 +24,26 @@ result yields an empty frame, never an error.
 ### Aggregation the sugar doesn't cover
 
 For stages `where` / `fields` / `limit` don't emit — `$group`, `$sort`, or an
-Elastic-backed collection's DSL — pass a full pipeline with `aggregate()`. It is
-sent through untouched.
+Elastic-backed collection's DSL — pass a full pipeline with `aggregate()`. The
+list of stages is sent to the server untouched and the result comes back as a
+DataFrame (one row per group here).
 
 ```python
 --8<-- "dataframes.py:aggregate"
+```
+
+If you want the records or memory-bounded batches instead of a frame, call
+`fetch(pipeline=[...])` and iterate the [`ReadResult`][clappform.ReadResult]
+rather than `aggregate()`.
+
+### Aggregation via a saved query
+
+When the aggregation is defined server-side as a saved query, you don't write
+the pipeline at all — the [`QueryHandle`][clappform.QueryHandle] carries its own
+collection and pipeline, so you just read it.
+
+```python
+--8<-- "dataframes.py:aggregate-query"
 ```
 
 ### Memory-bounded reads
@@ -46,37 +61,58 @@ records per gRPC chunk. `batch_size` asks the server to cap each chunk.
     thin wrappers (`read()` is literally `fetch().to_pandas()`); call `read()`
     again for a fresh pass rather than reusing a materialised result.
 
-## Write back
+## Insert new rows
 
-`update()` matches on `_id` by default; `append()` inserts new rows; `upsert()`
-inserts-or-updates on a business key (which has no default — you must pass
-`on=`). Uploads stream in chunks, so a failed chunk is retryable at the flow
-level rather than a whole-frame resend.
+`append()` inserts every row of the frame as a brand-new document and returns
+the number of rows written. Uploads stream in chunks, so a failed chunk is
+retryable at the flow level rather than a whole-frame resend.
 
 ```python
---8<-- "dataframes.py:write"
+--8<-- "dataframes.py:insert"
+```
+
+## Update existing rows
+
+`update()` matches on `_id` by default — the column `read()` keeps — so a
+read → mutate → write-back round-trip needs no arguments. Only the rows in the
+frame you pass are sent, so mutate a filtered slice to touch just those rows.
+
+```python
+--8<-- "dataframes.py:update"
+```
+
+## Upsert / sync on a business key
+
+`upsert()` inserts-or-updates keyed on a business column instead of `_id`. It
+has no default — you must pass `on=` — so the key is always explicit. This is
+the sync primitive: rows whose key already exists are updated in place, the
+rest are inserted, and re-running it never creates duplicates. It's what a
+cross-cluster or external-source sync builds on (see
+[Multi-cluster & multi-tenant](multi-cluster.md)).
+
+```python
+--8<-- "dataframes.py:upsert"
 ```
 
 ## Server-side mutate and delete
 
 When you don't need the rows client-side, `replace_where()` and `delete()` run
-entirely on the server — nothing is round-tripped through the client. To wipe a
-collection use `clear()`, which is explicit by design so a full delete is never
-an accident of an empty filter.
+entirely on the server — nothing is round-tripped through the client. `delete()`
+takes exactly one of `where=` (a filter) or `oids=` (specific `_id`s); an empty
+`where` is refused.
 
 ```python
 --8<-- "dataframes.py:server-side"
 ```
 
-## Saved queries
-
-A saved server-side query carries its own collection and pipeline, so a
-[`QueryHandle`][clappform.QueryHandle] is read-only: `cf.data.query(ref)` where
-`ref` is the query's name or UUID.
+To wipe a collection use `clear()`, which is separate from `delete()` by design
+so a full wipe is never an accident of an empty filter.
 
 ```python
---8<-- "dataframes.py:saved-query"
+--8<-- "dataframes.py:clear"
 ```
 
 See the [DataFrame surface reference](../reference/dataframes.md) for every
-method and argument.
+method and argument, and [Actionflows & listings](actionflows-and-listings.md)
+for the operations beyond the collection handle — starting actionflows and
+listing collections, apps and queries.

--- a/docs/guides/multi-cluster.md
+++ b/docs/guides/multi-cluster.md
@@ -27,6 +27,26 @@ a write on the other:
 --8<-- "multi_cluster.py:cross-cluster"
 ```
 
+## Moving a whole app between instances
+
+The copy above moves *rows*. To move an entire **app** — its collections and,
+optionally, its queries, actionflows and questionnaires — use the transfer
+RPCs. `export_app()` reads the bundle from the source instance and returns it as
+four byte blobs; `import_app()` writes those same blobs into the target. It's
+inherently a two-instance operation: read from one client, write to the other.
+
+```python
+--8<-- "multi_cluster.py:transfer-app"
+```
+
+The `include_*` flags on `export_app()` choose what travels with the app, and
+the `AppExport` it returns exposes exactly the `app` / `queries` / `actionflows`
+/ `questionnaires` fields `import_app()` consumes — so the hand-off is a direct
+pass-through with no reshaping. Pass `overwrite=True` on the import only when you
+intend to replace an app that already exists on the target; the default refuses
+to clobber it. `export_actionflow()` / `import_actionflow()` move a single
+actionflow the same way when you don't need the whole app.
+
 ## Another tenant on the same cluster
 
 `with_location()` gives a cheap clone bound to a different tenant. When the

--- a/docs/snippets/client_operations.py
+++ b/docs/snippets/client_operations.py
@@ -1,0 +1,134 @@
+"""Runnable source for the actionflows-&-listings guide snippets.
+
+These operations live on ``cf.client`` (not the DataFrame handle): starting an
+actionflow, and listing collections, apps, saved queries and cronjobs. None of
+them are data-plane RPCs, so ``LocalMock`` has no built-in handler — each is
+backed by an explicit ``.on()`` stub keyed on the full gRPC method path, which
+is exactly how you'd stub them in your own tests. Runs against ``LocalMock`` in
+CI so the guide's code matches the client.
+"""
+
+from __future__ import annotations
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+    from clappform.gen.clappform.client.v1.app import app_pb2
+    from clappform.gen.clappform.client.v1.collection import collection_pb2
+    from clappform.gen.clappform.client.v1.cronjob import cronjob_pb2
+    from clappform.gen.clappform.client.v1.query import query_pb2
+    from clappform.gen.clappform.v1.commons import commons_pb2
+
+    def one_page(*items: object) -> commons_pb2.Pagination:
+        # A single-page listing: pages == page terminates iter_get_all's loop.
+        return commons_pb2.Pagination(page=1, pages=1, total=len(items))
+
+    mock = LocalMock()
+
+    # Starting an actionflow returns the run's uuid so you can track it.
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="run-abc123"),
+    )
+    # A one-page listing of actionflows.
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/GetAll",
+        actionflow_pb2.Actionflows(
+            actionflows=[
+                actionflow_pb2.Actionflow(id="af-1", name="recalculate-dashboards"),
+                actionflow_pb2.Actionflow(id="af-2", name="nightly-export"),
+            ],
+            pagination=one_page("af-1", "af-2"),
+        ),
+    )
+    # Listing collections, apps, saved queries and cronjobs.
+    mock.on(
+        "/clappform.client.v1.collection.CollectionManagement/GetAll",
+        collection_pb2.Collections(
+            collections=[
+                collection_pb2.Collection(id="c-1", slug="sales_orders"),
+                collection_pb2.Collection(id="c-2", slug="customers"),
+            ],
+            pagination=one_page("c-1", "c-2"),
+        ),
+    )
+    mock.on(
+        "/clappform.client.v1.app.AppManagement/GetAll",
+        app_pb2.Apps(
+            apps=[app_pb2.App(id="a-1", slug="sales"), app_pb2.App(id="a-2", slug="ops")],
+            pagination=one_page("a-1", "a-2"),
+        ),
+    )
+    mock.on(
+        "/clappform.client.v1.query.QueryManagement/GetAll",
+        query_pb2.Queries(
+            queries=[query_pb2.Query(id="q-1", name="monthly-revenue-per-region")],
+            pagination=one_page("q-1"),
+        ),
+    )
+    mock.on(
+        "/clappform.client.v1.cronjob.CronjobManagement/GetAll",
+        cronjob_pb2.Cronjobs(
+            cronjobs=[cronjob_pb2.Cronjob(id="cj-1", name="nightly-sync", pattern="0 2 * * *")],
+            pagination=one_page("cj-1"),
+        ),
+    )
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    from clappform import Clappform
+
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+
+    with cf:
+        # --8<-- [start:start-actionflow]
+        # Trigger an actionflow by id. The response carries the run's uuid, so
+        # you can correlate it with the tasks it spawns.
+        started = cf.client.actionflow.start(id="recalculate-dashboards")
+        run_id = started.uuid
+        # --8<-- [end:start-actionflow]
+        assert run_id == "run-abc123"
+
+        # --8<-- [start:list-actionflows]
+        # iter_get_all() auto-paginates: it yields every actionflow across all
+        # pages, so you never manage `page` yourself.
+        for actionflow in cf.client.actionflow.iter_get_all():
+            handle(actionflow.name)
+
+        # Or take one page at a time when you want the pagination metadata.
+        page = cf.client.actionflow.get_all(limit=50)
+        total = page.pagination.total
+        # --8<-- [end:list-actionflows]
+        assert total == 2
+
+        # --8<-- [start:list-collections]
+        # Read every collection in the tenant. Each Collection carries its slug
+        # and id — the same id cf.data.collection(slug) resolves to under the
+        # hood, so this is how you discover what's there to read.
+        collections = list(cf.client.collection.iter_get_all())
+        slugs = [c.slug for c in collections]
+        # --8<-- [end:list-collections]
+        assert slugs == ["sales_orders", "customers"]
+
+        # --8<-- [start:list-others]
+        # The same get_all / iter_get_all pair lists apps, saved queries and
+        # cronjobs — anything on cf.client with a listing follows this shape.
+        apps = list(cf.client.app.iter_get_all())
+        queries = list(cf.client.query.iter_get_all())
+        cronjobs = list(cf.client.cronjob.iter_get_all())
+        # --8<-- [end:list-others]
+        assert [a.slug for a in apps] == ["sales", "ops"]
+        assert [q.name for q in queries] == ["monthly-revenue-per-region"]
+        assert [c.name for c in cronjobs] == ["nightly-sync"]
+
+
+def handle(name: str) -> None:
+    """Stand-in for whatever the caller does with each item."""
+    assert isinstance(name, str)
+
+
+if __name__ == "__main__":
+    run(build_mock())

--- a/docs/snippets/dataframes.py
+++ b/docs/snippets/dataframes.py
@@ -1,7 +1,8 @@
 """Runnable source for the DataFrame-flows guide snippets.
 
-Covers the read/filter, batch, append/update/upsert, replace-where and delete
-paths. Runs against ``LocalMock`` in CI so the guide's code matches the client.
+Covers the read/filter, batch, aggregate (collection pipeline + saved query),
+append/update/upsert/sync, replace-where and delete paths. Runs against
+``LocalMock`` in CI so the guide's code matches the client.
 """
 
 from __future__ import annotations
@@ -44,19 +45,31 @@ def run(transport: LocalMock) -> None:
 
         # --8<-- [start:aggregate]
         # For stages the sugar does not emit ($group, $sort, ...) pass a full
-        # pipeline. It is sent through untouched.
-        by_region = orders.aggregate(
+        # pipeline to aggregate(). It is sent to the server untouched and the
+        # result comes back as a DataFrame — one row per group here.
+        revenue_by_region = orders.aggregate(
             [
                 {"$match": {"status": "open"}},
                 {"$group": {"_id": "$region", "total": {"$sum": "$amount"}}},
+                {"$sort": {"total": -1}},
             ]
         )
         # --8<-- [end:aggregate]
         # The pipeline reaches the collection intact; LocalMock executes the
-        # $match it understands (2 open rows) and passes $group through without
-        # evaluating it, so this asserts the call round-trips, not that the mock
-        # reimplements $group.
-        assert len(by_region) == 2
+        # $match it understands (2 open rows) and passes $group/$sort through
+        # without evaluating them, so this asserts the call round-trips, not
+        # that the mock reimplements an aggregation engine.
+        assert len(revenue_by_region) == 2
+
+        # --8<-- [start:aggregate-query]
+        # A saved server-side query already carries its own collection and
+        # pipeline, so you just read it — no pipeline to write client-side.
+        revenue = cf.data.query("monthly-revenue-per-region")
+        revenue_df = revenue.read()
+        # --8<-- [end:aggregate-query]
+        # The saved query reads the same backing collection, so it tracks the
+        # live store rather than a hard-coded count.
+        assert len(revenue_df) == len(transport.records("sales_orders-id"))
 
         # --8<-- [start:batches]
         # Memory-bounded reads: one list of records per gRPC chunk, nothing
@@ -65,36 +78,65 @@ def run(transport: LocalMock) -> None:
             handle(batch)
         # --8<-- [end:batches]
 
-        # --8<-- [start:write]
+        # --8<-- [start:insert]
+        # append() inserts every row as a brand-new document. Build the frame
+        # however you like — here from a list of dicts.
+        import pandas as pd
+
+        new_orders = pd.DataFrame(
+            [
+                {"order_id": "A-9", "amount": 10.0, "status": "open", "region": "EU"},
+                {"order_id": "A-10", "amount": 25.0, "status": "open", "region": "US"},
+            ]
+        )
+        written = orders.append(new_orders)  # returns the row count written
+        # --8<-- [end:insert]
+        assert written == 2
+
+        # --8<-- [start:update]
         # read -> mutate -> write-back. update() keys on _id by default, which
-        # read() keeps as a column, so the round-trip needs no `on=`.
-        df["amount"] = df["amount"] * 1.08
-        orders.update(df)
+        # read() keeps as a column, so the round-trip needs no `on=`. Only the
+        # rows you changed are sent.
+        open_orders = orders.read(where={"status": "open"})
+        open_orders["amount"] = open_orders["amount"] * 1.08  # 8% uplift
+        orders.update(open_orders)
+        # --8<-- [end:update]
 
-        # insert brand-new rows
-        new_rows = df.head(0).assign(order_id=["A-9"], amount=[10.0], region=["EU"])
-        orders.append(new_rows)
-
-        # insert-or-update on a business key (no default — `on` is required)
-        orders.upsert(df, on="order_id")
-        # --8<-- [end:write]
+        # --8<-- [start:upsert]
+        # upsert() inserts-or-updates on a business key — no _id needed. `on`
+        # has no default: you must name the key column. Rows whose key exists
+        # are updated in place; the rest are inserted.
+        incoming = pd.DataFrame(
+            [
+                {"order_id": "A-1", "amount": 200.0, "status": "open", "region": "EU"},
+                {"order_id": "A-99", "amount": 5.0, "status": "open", "region": "APAC"},
+            ]
+        )
+        orders.upsert(incoming, on="order_id")
+        # --8<-- [end:upsert]
+        # A-1 updated in place, A-99 inserted — no duplicate A-1.
+        by_key = {row["order_id"]: row for row in transport.records("sales_orders-id")}
+        assert by_key["A-1"]["amount"] == 200.0
+        assert by_key["A-99"]["region"] == "APAC"
 
         # --8<-- [start:server-side]
-        # Mutate or delete without pulling rows through the client.
+        # Mutate or delete without pulling rows through the client. Both run
+        # entirely on the server — nothing is round-tripped.
         orders.replace_where({"status": "open"}, {"reviewed": True})
         orders.delete(where={"status": "closed"})
-        # --8<-- [end:server-side]
 
-        # --8<-- [start:saved-query]
-        # A saved server-side query carries its own collection + pipeline.
-        revenue = cf.data.query("monthly-revenue-per-region")
-        revenue_df = revenue.read()
-        # --8<-- [end:saved-query]
-        # The saved query reads the same backing collection this snippet has
-        # been mutating, so it returns whatever rows now remain — assert it
-        # tracks the live store rather than a hard-coded count.
-        assert len(revenue_df) == len(transport.records("sales_orders-id"))
-        assert len(revenue_df) > 0
+        # Delete specific rows by their _id instead of a filter.
+        stale = orders.read(where={"region": "APAC"})
+        orders.delete(oids=list(stale["_id"]))
+        # --8<-- [end:server-side]
+        assert not any(row.get("region") == "APAC" for row in transport.records("sales_orders-id"))
+
+        # --8<-- [start:clear]
+        # clear() empties the whole collection. It is separate from delete() by
+        # design, so a full wipe is never an accident of an empty filter.
+        orders.clear()
+        # --8<-- [end:clear]
+        assert transport.records("sales_orders-id") == []
 
 
 def handle(batch: list) -> None:

--- a/docs/snippets/multi_cluster.py
+++ b/docs/snippets/multi_cluster.py
@@ -26,6 +26,9 @@ def run(prod_transport: LocalMock, qa_transport: LocalMock) -> None:
     prod = Clappform(cluster="prod", location="acme", api_key="x", transport=prod_transport)
     qa = Clappform(cluster="qa", location="acme", api_key="x", transport=qa_transport)
 
+    imported: dict[str, bytes] = {}
+    _register_transfer_stubs(prod_transport, qa_transport, imported)
+
     with prod, qa:
         # --8<-- [start:cross-cluster]
         # Pull from prod, mirror into qa by business key.
@@ -44,6 +47,71 @@ def run(prod_transport: LocalMock, qa_transport: LocalMock) -> None:
         # --8<-- [end:with-location]
         # the clone shares prod's transport, so it reads prod's seeded row
         assert len(beta_orders) == 1
+
+        # --8<-- [start:transfer-app]
+        # Move a whole app — its collections, and optionally its queries,
+        # actionflows and questionnaires — from one instance to another.
+        # export_app() reads the bundle from the source; import_app() writes it
+        # into the target. The AppExport's four byte blobs are exactly the
+        # fields import_app() consumes, so the hand-off needs no reshaping.
+        bundle = prod.client.transfer.export_app(
+            id="sales-dashboard",
+            include_app=True,
+            include_queries=True,
+            include_actionflows=True,
+            include_questionnaires=True,
+        )
+
+        qa.client.transfer.import_app(
+            app=bundle.app,
+            queries=bundle.queries,
+            actionflows=bundle.actionflows,
+            questionnaires=bundle.questionnaires,
+            overwrite=False,  # refuse to clobber an app already on the target
+        )
+        # --8<-- [end:transfer-app]
+        # the exact blobs exported from prod reached qa's import handler intact
+        assert imported == {
+            "app": b"<app-bundle>",
+            "queries": b"<queries-bundle>",
+            "actionflows": b"<actionflows-bundle>",
+            "questionnaires": b"<questionnaires-bundle>",
+        }
+
+
+def _register_transfer_stubs(
+    source: LocalMock, target: LocalMock, captured: dict[str, bytes]
+) -> None:
+    """Stub ExportApp on the source and ImportApp on the target.
+
+    Transfer RPCs are not data-plane calls, so LocalMock has no built-in
+    handler — the same ``.on()`` stubbing you'd use in your own tests. The
+    import stub is a handler that captures the received blobs so the snippet
+    can assert the bundle crossed instances intact.
+    """
+    from clappform.gen.clappform.client.v1.transfer import transfer_pb2
+    from clappform.gen.clappform.v1.commons import commons_pb2
+
+    source.on(
+        "/clappform.client.v1.transfer.TransferManagement/ExportApp",
+        transfer_pb2.AppExport(
+            app=b"<app-bundle>",
+            queries=b"<queries-bundle>",
+            actionflows=b"<actionflows-bundle>",
+            questionnaires=b"<questionnaires-bundle>",
+        ),
+    )
+
+    def _capture_import(request: transfer_pb2.AppImport) -> commons_pb2.Message:
+        captured.update(
+            app=request.app,
+            queries=request.queries,
+            actionflows=request.actionflows,
+            questionnaires=request.questionnaires,
+        )
+        return commons_pb2.Message(message="app imported")
+
+    target.on("/clappform.client.v1.transfer.TransferManagement/ImportApp", _capture_import)
 
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Quickstart: quickstart.md
   - How-to guides:
       - DataFrame flows: guides/dataframes.md
+      - Actionflows & listings: guides/actionflows-and-listings.md
       - Multi-cluster & multi-tenant: guides/multi-cluster.md
       - Error handling & retries: guides/errors-and-retries.md
       - Testing with LocalMock: guides/testing.md

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -35,6 +35,7 @@ def test_snippets_directory_is_present() -> None:
     assert {
         "quickstart",
         "dataframes",
+        "client_operations",
         "multi_cluster",
         "errors_and_retries",
         "testing",
@@ -53,6 +54,11 @@ def test_dataframes_snippet_runs() -> None:
     module.run(mock)
 
 
+def test_client_operations_snippet_runs() -> None:
+    module = _load("client_operations")
+    module.run(module.build_mock())
+
+
 def test_multi_cluster_snippet_runs() -> None:
     module = _load("multi_cluster")
     module.run(module.build_mock(), module.build_mock())
@@ -68,7 +74,7 @@ def test_testing_snippet_runs() -> None:
     module.run()
 
 
-@pytest.mark.parametrize("name", ["quickstart", "dataframes", "multi_cluster"])
+@pytest.mark.parametrize("name", ["quickstart", "dataframes", "client_operations", "multi_cluster"])
 def test_snippet_modules_import_clean(name: str) -> None:
     """Importing a snippet module must have no side effects (no top-level run)."""
     module = _load(name)

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -74,7 +74,9 @@ def test_testing_snippet_runs() -> None:
     module.run()
 
 
-@pytest.mark.parametrize("name", ["quickstart", "dataframes", "client_operations", "multi_cluster"])
+@pytest.mark.parametrize(
+    "name", ["quickstart", "dataframes", "client_operations", "multi_cluster"]
+)
 def test_snippet_modules_import_clean(name: str) -> None:
     """Importing a snippet module must have no side effects (no top-level run)."""
     module = _load(name)


### PR DESCRIPTION
## What

Expands the docs with runnable usage examples for common operations, following the repo's snippet convention (each example lives in `docs/snippets/*.py`, runs against `LocalMock`, and is driven by a test — so it can't rot).

### DataFrame flows (`docs/guides/dataframes.md`)
- **Aggregates** — via a collection + custom pipeline (`$match → $group → $sort`) and via a saved query
- **Insert** (`append`), **update** (read → mutate → write-back on `_id`), **upsert/sync** on a business key
- **Server-side delete** (both `where=` and `oids=` forms) and **clear**

### Actionflows & listings (new guide)
- **Start an actionflow** — `cf.client.actionflow.start(id=...)`
- **Read all collections**, and list **apps / saved queries / cronjobs** via the `get_all` / auto-paginating `iter_get_all` pair

### Transfer export/import (`docs/guides/multi-cluster.md`)
- **Move a whole app between instances** — `export_app()` on a source client handing its bundle straight to `import_app()` on a target client

## Testing

- `pytest tests/test_docs_snippets.py` — **11 passed** (2 new tests + the existing multi-cluster test now covers transfer)
- `mkdocs build --strict` — **exit 0** (all `--8<--` include anchors and cross-references resolve)

Non-data-plane RPCs (actionflows, listings, transfer) are backed by explicit `.on()` stubs in the snippets — the same pattern the testing guide documents for stubbing in your own tests.
