### PR TITLE
feat: Arrow output stubs and namespace discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,13 @@ ignore_errors = true
 module = "pandas.*"
 ignore_missing_imports = true
 
+# Optional columnar deps: reserved for the server-gated Arrow read path, imported
+# lazily and behind the [arrow]/[polars] extras. pyarrow ships no py.typed marker
+# and polars may be absent entirely, so treat both like pandas above.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*", "polars.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/clappform/_client.py
+++ b/src/clappform/_client.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from clappform import _discovery, _resolve, _runtime, dataframes
+from clappform import _discovery, _namespace, _resolve, _runtime, dataframes
 from clappform._auth import ApiKey, Credentials
 from clappform._errors import ConfigurationError
 from clappform._transport import (
@@ -69,6 +69,21 @@ class Clappform:
         client: ClientAPI
         auth: AuthAPI
         notifier: NotifierAPI
+
+    # Curated top-level conveniences hoisted onto ``cf`` from a deeper path,
+    # as an explicit allowlist of ``shortcut -> owning family``. Deliberately
+    # tiny: only *globally-unambiguous*, high-traffic entry points belong here,
+    # and _attach_dataframe_handles refuses to hoist any name the derived index
+    # shows on more than one family. The two-level ``cf.<family>.<service>``
+    # path stays the canonical form regardless of what is hoisted.
+    #
+    # Intentionally empty for now. The obvious DataFrame candidates —
+    # ``collection`` / ``query`` — are NOT globally unambiguous: both are real
+    # service names on cf.client, so hoisting them onto ``cf`` would shadow a
+    # different family's surface. They stay at their canonical home,
+    # ``cf.data.collection(...)`` / ``cf.data.query(...)``. New entries are
+    # added here only after review confirms the name is unambiguous.
+    _SHORTCUTS: dict[str, str] = {}
 
     def __init__(
         self,
@@ -147,6 +162,26 @@ class Clappform:
         self.data.collection = collection  # type: ignore[attr-defined]
         self.data.query = query  # type: ignore[attr-defined]
 
+        # Hoist the curated shortcuts onto the client itself so cf.collection(...)
+        # resolves to the same callable as cf.data.collection(...). The
+        # allowlist is checked against the derived name index so an ambiguous
+        # name can never be hoisted silently.
+        index = _namespace.name_index()
+        for shortcut, family in self._SHORTCUTS.items():
+            owners = index.get(shortcut)
+            if owners is not None and owners != [family]:
+                raise ConfigurationError(
+                    f"refusing to hoist ambiguous shortcut {shortcut!r}: "
+                    f"it also names a service/method on {owners}"
+                )
+            target = getattr(self, family)
+            if not hasattr(target, shortcut):
+                raise ConfigurationError(
+                    f"cannot hoist shortcut {shortcut!r}: "
+                    f"cf.{family} has no attribute {shortcut!r}"
+                )
+            setattr(self, shortcut, getattr(target, shortcut))
+
     def with_location(self, location: str) -> Clappform:
         """A clone bound to another tenant, sharing connections when possible.
 
@@ -201,6 +236,52 @@ class Clappform:
 
     def __exit__(self, *exc_info: object) -> None:
         self.close()
+
+    def __getattr__(self, name: str) -> Any:
+        """Turn a wrong-family / typo access into an actionable error.
+
+        Only reached when normal lookup misses (the bound families and curated
+        shortcuts resolve first). If ``name`` is a real service or method name
+        living on a family, say so — ``cf.insert`` -> "``insert`` lives on
+        cf.data". Otherwise fall back to the standard ``AttributeError``.
+        """
+        # Dunder / private probes (copy, pickle, etc.) must miss cleanly.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        hint = _namespace.wrong_family_hint(name)
+        if hint is not None:
+            raise AttributeError(hint)
+        raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+
+    def __dir__(self) -> list[str]:
+        """List the four families and the curated shortcuts alongside the
+        regular attributes, so tab-completion surfaces the entry points."""
+        from clappform.services import API_FAMILIES
+
+        names = set(super().__dir__())
+        names.update(API_FAMILIES)
+        names.update(self._SHORTCUTS)
+        return sorted(names)
+
+    def help(self, name: str | None = None) -> str:
+        """Answer "which family owns ``<name>``?", or list the families.
+
+        With no argument, returns the four family names plus curated shortcuts.
+        With a name, returns the wrong-family hint (or notes it is unknown).
+        """
+        from clappform.services import API_FAMILIES
+
+        if name is None:
+            families = ", ".join(f"cf.{f}" for f in sorted(API_FAMILIES))
+            summary = f"API families: {families}."
+            if self._SHORTCUTS:
+                shortcuts = ", ".join(f"cf.{s}" for s in sorted(self._SHORTCUTS))
+                summary += f" Shortcuts: {shortcuts}."
+            return summary
+        hint = _namespace.wrong_family_hint(name)
+        if hint is not None:
+            return hint
+        return f"{name!r} is not a known Clappform service or method"
 
     def __repr__(self) -> str:
         from clappform import __proto_version__, __version__

--- a/src/clappform/_namespace.py
+++ b/src/clappform/_namespace.py
@@ -1,0 +1,90 @@
+"""Name -> API-family index for friendly wrong-family / typo errors.
+
+The public surface is intentionally two levels deep — ``cf.data.insert(...)``,
+``cf.auth.api_key(...)`` — because names are only unique at the gRPC-path level,
+not at the flat Python-attribute level (``create`` / ``get`` / ``delete`` recur
+across ~18 services, and ``general`` / ``process`` / ``version`` name services in
+more than one family, on different hosts). Flattening the surface onto ``cf``
+would silently misroute; see DESIGN.md §3.2.
+
+So the family segment stays, and this module delivers the ergonomics the
+flattening was reaching for: reach for a service or method name on the wrong
+object and you get told its real home instead of a bare ``AttributeError``.
+
+The index is *derived* from :data:`clappform.services.API_FAMILIES` at import
+time, never hand-maintained: a new RPC in the generated layer appears in the
+hint automatically. Colliding names map to *all* their owning families rather
+than guessing one.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+class _NullCaller:
+    """A do-nothing caller used only to instantiate family classes for
+    introspection. Family/service constructors just stash the caller, so no RPC
+    is ever attempted through this."""
+
+    def invoke(self, *args: object, **kwargs: object) -> object:  # pragma: no cover - never called
+        raise RuntimeError("introspection caller must not be invoked")
+
+
+def _iter_service_and_method_names(family_cls: type) -> tuple[list[str], dict[str, list[str]]]:
+    """Return (service attribute names, {method_name: [service names]}) for a
+    family class, by introspecting a throwaway instance."""
+    instance = family_cls(_NullCaller())
+    services: list[str] = []
+    methods: dict[str, list[str]] = {}
+    for attr in vars(instance):
+        if attr.startswith("_"):
+            continue
+        services.append(attr)
+        service = getattr(instance, attr)
+        for name in dir(type(service)):
+            if name.startswith("_"):
+                continue
+            if callable(getattr(type(service), name, None)):
+                methods.setdefault(name, []).append(attr)
+    return services, methods
+
+
+@lru_cache(maxsize=1)
+def name_index() -> dict[str, list[str]]:
+    """Map every service and method name to the families that own it.
+
+    Built once and cached. A name owned by several families (e.g. ``general``,
+    ``process``) lists all of them, sorted, so the hint can name every home
+    rather than picking one.
+    """
+    from clappform.services import API_FAMILIES
+
+    index: dict[str, set[str]] = {}
+    for family, family_cls in API_FAMILIES.items():
+        services, methods = _iter_service_and_method_names(family_cls)
+        for service_name in services:
+            index.setdefault(service_name, set()).add(family)
+        for method_name in methods:
+            index.setdefault(method_name, set()).add(family)
+    return {name: sorted(families) for name, families in index.items()}
+
+
+def wrong_family_hint(name: str) -> str | None:
+    """A one-line hint telling the caller where ``name`` actually lives, or
+    ``None`` if the name is not a known service/method anywhere.
+
+    Colliding names name every owning family so the caller is never quietly
+    pointed at the wrong host.
+    """
+    families = name_index().get(name)
+    if not families:
+        return None
+    if len(families) == 1:
+        family = families[0]
+        return f"{name!r} lives on cf.{family}, not on the client directly"
+    homes = " or ".join(f"cf.{f}" for f in families)
+    return (
+        f"{name!r} exists on more than one API family ({homes}); "
+        f"reach it through the family that owns your data"
+    )

--- a/src/clappform/dataframes.py
+++ b/src/clappform/dataframes.py
@@ -48,6 +48,42 @@ def _require_pandas() -> Any:
     return pd
 
 
+def _require_pyarrow() -> Any:
+    """Import pyarrow, turning the ImportError into an actionable message."""
+    try:
+        import pyarrow as pa
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ClappformError(
+            "pyarrow is required for Arrow conversion; "
+            "install it with: pip install clappform[arrow]"
+        ) from exc
+    return pa
+
+
+def _require_polars() -> Any:
+    """Import polars, turning the ImportError into an actionable message."""
+    try:
+        import polars as pl
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ClappformError(
+            "polars is required for Polars conversion; "
+            "install it with: pip install clappform[polars]"
+        ) from exc
+    return pl
+
+
+# The server does not yet emit Arrow IPC on the streaming data plane, so the
+# columnar surfaces below cannot produce a result even with pyarrow/polars
+# installed. They exist now — failing loudly rather than as AttributeError — so
+# the names are reserved and callers discover the capability; they light up
+# (as a purely additive change) once a cluster negotiates the Arrow format.
+_ARROW_NOT_READY = (
+    "Arrow output is not available yet: this client version always reads JSON, "
+    "and Arrow lands as an additive surface once server Arrow support ships on "
+    "your cluster. Track the v6 Arrow read-path work for availability."
+)
+
+
 def _records_from_frame(df: pd.DataFrame) -> list[Record]:
     """Turn a DataFrame into plain records (the codec's input form).
 
@@ -69,9 +105,10 @@ class ReadResult:
 
     Shipping this now (rather than returning a DataFrame straight from
     ``read()``) is deliberate: ``to_polars`` / ``to_arrow`` / the Arrow
-    PyCapsule protocol land as new methods here without changing any existing
-    return type, and the batch-wise internals let a future Arrow reader map one
-    Arrow batch per gRPC chunk.
+    PyCapsule protocol are reserved as methods here (they raise until server
+    Arrow support ships) so they can light up as a purely additive change, and
+    the batch-wise internals let that future Arrow reader map one Arrow batch
+    per gRPC chunk.
     """
 
     __slots__ = ("_chunks", "_consumed")
@@ -108,6 +145,46 @@ class ReadResult:
         pd = _require_pandas()
         records = list(self)
         return pd.DataFrame.from_records(records)
+
+    def to_arrow(self) -> Any:
+        """Materialise the result set as a ``pyarrow.Table`` (reserved).
+
+        The fast, zero-per-row-object base the other columnar surfaces build on:
+        once the server negotiates Arrow IPC, one gRPC chunk maps to one Arrow
+        record batch and this returns a ``Table`` without ever materialising
+        Python rows. Requires ``pip install clappform[arrow]``.
+
+        Reserved for the v6 Arrow read path; raises until server Arrow support
+        ships (the JSON path via :meth:`to_pandas` handles today's reads).
+        """
+        _require_pyarrow()
+        raise NotImplementedError(_ARROW_NOT_READY)
+
+    def to_polars(self) -> Any:
+        """Materialise the result set as a ``polars.DataFrame`` (reserved).
+
+        Built on :meth:`to_arrow` (zero-copy ``pl.from_arrow``), so once
+        implemented it needs pyarrow as well as polars — install
+        ``clappform[polars,arrow]`` (or ``clappform[all]``). This stub only
+        checks for polars, as it raises before any Arrow conversion runs.
+
+        Reserved for the v6 Arrow read path; raises until server Arrow support
+        ships.
+        """
+        _require_polars()
+        raise NotImplementedError(_ARROW_NOT_READY)
+
+    def __arrow_c_stream__(self, requested_schema: object | None = None) -> Any:
+        """Arrow PyCapsule stream interface (reserved).
+
+        Lets Arrow-native consumers (Polars, DuckDB, ...) pull results directly
+        with no clappform glue. Requires ``pip install clappform[arrow]``.
+
+        Reserved for the v6 Arrow read path; raises until server Arrow support
+        ships.
+        """
+        _require_pyarrow()
+        raise NotImplementedError(_ARROW_NOT_READY)
 
 
 class _AggregateReader:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,144 @@
+"""Namespace discoverability: wrong-family hints, dir(), help(), shortcuts.
+
+The public surface stays two levels deep (``cf.data.insert``) because names are
+only unique at the gRPC-path level. These tests pin the ergonomics that make
+the split friendly: reach for a name on the wrong object and you are told its
+real home; colliding names name *every* owning family; the curated shortcut
+allowlist never hoists an ambiguous name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clappform import Clappform, ConfigurationError, _namespace
+
+
+class _NullTransport:
+    def invoke(self, *args, **kwargs):
+        raise RuntimeError("no RPC should be attempted in these tests")
+
+
+def make_client() -> Clappform:
+    return Clappform("acme", "qa", api_key="k", transport=_NullTransport())
+
+
+# --- the derived index -------------------------------------------------------
+
+def test_index_is_derived_from_api_families_not_hand_maintained() -> None:
+    # A representative service/method from each family must appear, proving the
+    # index is built by introspecting API_FAMILIES rather than a static list.
+    index = _namespace.name_index()
+    assert "insert" in index          # data method
+    assert "aggregate" in index       # data service
+    assert index["insert"] == ["data"]
+
+
+def test_colliding_names_list_all_owning_families() -> None:
+    index = _namespace.name_index()
+    # These service names exist on more than one family (different hosts).
+    assert index["general"] == ["auth", "client", "data", "notifier"]
+    assert index["process"] == ["client", "data"]
+    assert index["version"] == ["auth", "client"]
+
+
+def test_index_is_cached() -> None:
+    assert _namespace.name_index() is _namespace.name_index()
+
+
+# --- hints -------------------------------------------------------------------
+
+def test_hint_for_unique_name_names_the_one_family() -> None:
+    hint = _namespace.wrong_family_hint("insert")
+    assert "cf.data" in hint
+    assert "not on the client directly" in hint
+
+
+def test_hint_for_colliding_name_names_every_family() -> None:
+    hint = _namespace.wrong_family_hint("process")
+    assert "cf.client" in hint and "cf.data" in hint
+
+
+def test_hint_for_unknown_name_is_none() -> None:
+    assert _namespace.wrong_family_hint("definitely_not_a_service") is None
+
+
+# --- client integration ------------------------------------------------------
+
+def test_wrong_family_access_raises_with_hint() -> None:
+    cf = make_client()
+    with pytest.raises(AttributeError, match=r"insert.*lives on cf\.data"):
+        cf.insert  # noqa: B018 - the access itself is what triggers __getattr__
+
+
+def test_colliding_access_lists_families() -> None:
+    cf = make_client()
+    with pytest.raises(AttributeError, match=r"cf\.client.*cf\.data|cf\.data.*cf\.client"):
+        cf.process  # noqa: B018 - the access itself is what triggers __getattr__
+
+
+def test_genuine_typo_gets_plain_attribute_error() -> None:
+    cf = make_client()
+    with pytest.raises(AttributeError, match="has no attribute 'totally_made_up'"):
+        cf.totally_made_up  # noqa: B018 - the access itself is what triggers __getattr__
+
+
+def test_private_attribute_miss_stays_a_plain_attributeerror() -> None:
+    # Dunder / private probes (copy, pickle, hasattr on internals) must miss
+    # cleanly without going through the hint machinery.
+    cf = make_client()
+    with pytest.raises(AttributeError):
+        cf.__wrapped__  # noqa: B018
+    assert not hasattr(cf, "_not_a_real_private_attr")
+
+
+def test_dir_lists_the_four_families() -> None:
+    cf = make_client()
+    listing = set(dir(cf))
+    assert {"data", "client", "auth", "notifier"} <= listing
+
+
+def test_help_without_argument_lists_families() -> None:
+    cf = make_client()
+    summary = cf.help()
+    for family in ("cf.data", "cf.client", "cf.auth", "cf.notifier"):
+        assert family in summary
+
+
+def test_help_with_name_returns_the_hint() -> None:
+    cf = make_client()
+    assert "cf.data" in cf.help("insert")
+    assert "not a known" in cf.help("definitely_not_a_service")
+
+
+# --- canonical path stays intact --------------------------------------------
+
+def test_dataframe_entry_points_stay_on_cf_data() -> None:
+    cf = make_client()
+    assert callable(cf.data.collection)
+    assert callable(cf.data.query)
+
+
+def test_shortcut_allowlist_is_empty_by_default() -> None:
+    # Nothing is hoisted yet: collection/query are ambiguous (also on cf.client),
+    # so they stay at cf.data.* until a reviewed, unambiguous name is added.
+    assert Clappform._SHORTCUTS == {}
+
+
+# --- shortcut guard ----------------------------------------------------------
+
+def test_guard_refuses_to_hoist_an_ambiguous_shortcut(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 'process' lives on both cf.client and cf.data; trying to hoist it must
+    # fail loudly rather than silently shadow one family.
+    monkeypatch.setattr(Clappform, "_SHORTCUTS", {"process": "data"})
+    with pytest.raises(ConfigurationError, match="ambiguous shortcut 'process'"):
+        make_client()
+
+
+def test_guard_rejects_a_shortcut_absent_from_its_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A shortcut naming nothing on its declared family (a typo'd allowlist
+    # entry) must fail with a clear config error, not a raw AttributeError
+    # from deep in service binding.
+    monkeypatch.setattr(Clappform, "_SHORTCUTS", {"no_such_entry_point": "data"})
+    with pytest.raises(ConfigurationError, match="cannot hoist shortcut 'no_such_entry_point'"):
+        make_client()

--- a/tests/test_readresult_arrow_stubs.py
+++ b/tests/test_readresult_arrow_stubs.py
@@ -1,0 +1,100 @@
+"""Reserved Arrow output surfaces on ``ReadResult``.
+
+The Arrow read path is server-gated: this client version always reads JSON, so
+``to_arrow`` / ``to_polars`` / ``__arrow_c_stream__`` exist but do not yet
+produce a result. They must fail *loudly and helpfully* rather than as a bare
+``AttributeError``:
+
+* dependency missing  -> ``ClappformError`` telling you to ``pip install`` the
+  right extra (lazy import, same pattern as ``to_pandas``);
+* dependency present  -> ``NotImplementedError`` saying server Arrow support
+  has not shipped.
+
+These tests pin both branches deterministically regardless of whether pyarrow /
+polars happen to be installed in the test environment.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from clappform._codec import ChunkFormat
+from clappform._errors import ClappformError
+from clappform.dataframes import ReadResult
+
+
+def _empty_result() -> ReadResult:
+    return ReadResult(iter([(ChunkFormat.JSON, b"[]")]))
+
+
+def _hide_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Make ``import <name>`` raise ImportError, even if it is installed."""
+    real_import = builtins.__import__
+
+    def fake_import(mod, *args, **kwargs):
+        if mod == name or mod.startswith(name + "."):
+            raise ImportError(f"{name} hidden for test")
+        return real_import(mod, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _provide_module(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Ensure ``import <name>`` succeeds, injecting a stub if not installed."""
+    import sys
+    import types
+
+    if name not in sys.modules:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+
+
+# --- missing-dependency branch: friendly install hint -----------------------
+
+def test_to_arrow_without_pyarrow_points_at_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hide_module(monkeypatch, "pyarrow")
+    with pytest.raises(ClappformError, match=r"clappform\[arrow\]"):
+        _empty_result().to_arrow()
+
+
+def test_to_polars_without_polars_points_at_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hide_module(monkeypatch, "polars")
+    with pytest.raises(ClappformError, match=r"clappform\[polars\]"):
+        _empty_result().to_polars()
+
+
+def test_arrow_stream_without_pyarrow_points_at_the_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hide_module(monkeypatch, "pyarrow")
+    with pytest.raises(ClappformError, match=r"clappform\[arrow\]"):
+        _empty_result().__arrow_c_stream__()
+
+
+# --- dependency-present branch: server not ready yet ------------------------
+
+def test_to_arrow_with_pyarrow_reports_server_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _provide_module(monkeypatch, "pyarrow")
+    with pytest.raises(NotImplementedError, match="not available yet"):
+        _empty_result().to_arrow()
+
+
+def test_to_polars_with_polars_reports_server_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _provide_module(monkeypatch, "polars")
+    with pytest.raises(NotImplementedError, match="not available yet"):
+        _empty_result().to_polars()
+
+
+def test_arrow_stream_with_pyarrow_reports_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _provide_module(monkeypatch, "pyarrow")
+    with pytest.raises(NotImplementedError, match="not available yet"):
+        _empty_result().__arrow_c_stream__()
+
+
+# --- reserved, not AttributeError -------------------------------------------
+
+def test_reserved_methods_exist_rather_than_attributeerror() -> None:
+    # The whole point of Phase 0: the names are present so callers discover the
+    # capability and get a clear message, never a bare AttributeError.
+    result = _empty_result()
+    for name in ("to_arrow", "to_polars", "__arrow_c_stream__"):
+        assert callable(getattr(result, name))


### PR DESCRIPTION
## Summary

- Reserve the Arrow output surfaces on `ReadResult` — `to_arrow()`, `to_polars()`, `__arrow_c_stream__()` — so the server-gated Arrow read path can land as a purely additive change. Each lazy-imports its optional dependency and points at the right extra when missing; with the dependency present it reports that server Arrow support has not shipped yet, rather than raising `AttributeError`.
- Add friendly wrong-family / typo errors on the client: `cf.insert` now tells you it lives on `cf.data`, and names owned by more than one family (`general`, `process`, `version`) list every owner so no call is quietly misrouted. Backed by a name-to-family index derived from `API_FAMILIES` at import time — no hand maintenance.
- `dir(cf)` surfaces the four families; `cf.help()` answers "which family owns this name?".
- Add a curated top-level shortcut allowlist with a guard that refuses to hoist any name that is ambiguous across families or absent from its declared family. The allowlist is intentionally empty for review (see Notes).

## Related issues

- Closes #59 — v6: Phase 0 — reserve [arrow]/[polars] extras + stub ReadResult Arrow methods
- Closes #57 — v6: namespace discoverability — friendly wrong-family errors + curated cf-level shortcuts

## Tests

- `tests/test_readresult_arrow_stubs.py` — both branches (missing-dep install hint, dep-present server-not-ready) of each reserved method, pinned deterministically by hiding/providing the optional module; names exist rather than `AttributeError`.
- `tests/test_namespace.py` — derived index and colliding-name resolution, wrong-family/multi-family hints through the client, plain `AttributeError` for genuine typos and private probes, `dir()`/`help()` contents, the shortcut guard rejecting ambiguous and absent entries, and the canonical `cf.data.collection` / `cf.data.query` path staying intact.
- `ruff check .`, `mypy src/clappform tools`, and `pytest` all passing locally (259 passed, 3 pre-existing env-gated skips).

## Notes

- Design of record: the two issue bodies (each carries a full Scope + Acceptance criteria section), plus DESIGN.md §3.2 ("why the family segment stays") for the namespace work and the v6 Arrow read-path planning docs for the stubs.
- `[arrow]` / `[polars]` extras were already reserved in `pyproject.toml`; this PR adds the reserved methods that pair with them and a mypy override so the lazy imports type-check without stubs.
- **Curated shortcuts — empty by design, needs a review call.** The obvious DataFrame candidates `collection` / `query` are *not* globally unambiguous: both are real service names on `cf.client`, so hoisting them onto `cf` would shadow another family's surface. They stay at their canonical `cf.data.collection(...)` / `cf.data.query(...)` home. The hoisting mechanism and its guard are in place; a reviewed, unambiguous name can be added to `Clappform._SHORTCUTS` later.
- Follow-up: when `to_polars()` is implemented it will need pyarrow as well as polars (`pl.from_arrow`), so the eventual dependency is `clappform[polars,arrow]` / `clappform[all]`; the stub docstring notes this.
- Base branch is `Major/6`; `Closes #N` records intent but will not auto-close on merge into a non-default branch — the tickets are closed on merge.

