### PR TITLE
feat: surface discovered cluster in errors; docs lead with discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Nothing is read from the environment; you pass everything in.
 ```python
 from clappform import Clappform
 
-cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...")
+# The cluster is discovered from DNS, so location and an API key are all you need.
+cf = Clappform(location="acme", api_key="cf_live_...")
 
 with cf:
     orders = cf.data.collection("sales_orders")

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,8 @@ multi-tenant support.
 ```python
 from clappform import Clappform
 
-cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...")
+# The cluster is discovered from DNS — location and an API key are all you need.
+cf = Clappform(location="acme", api_key="cf_live_...")
 df = cf.data.collection("sales_orders").read(where={"status": "open"})
 ```
 

--- a/docs/snippets/quickstart.py
+++ b/docs/snippets/quickstart.py
@@ -36,11 +36,16 @@ def run(transport: LocalMock) -> None:
     # --8<-- [start:connect]
     from clappform import Clappform
 
+    # location is your tenant subdomain (sent on every call); the cluster it
+    # lives on is discovered from DNS, so this is all you normally need.
     cf = Clappform(
-        location="acme",            # your tenant subdomain, sent on every call
-        cluster="prod",             # host extension; omit to discover it via DNS
+        location="acme",            # your tenant subdomain
         api_key="cf_live_...",      # the only credential v6 ships
     )
+
+    # In air-gapped or split-DNS environments where discovery can't run, pin
+    # the cluster explicitly — that skips DNS entirely.
+    cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...")
     # --8<-- [end:connect]
 
     # The docs example connects for real; the test swaps in a stubbed transport

--- a/src/clappform/_client.py
+++ b/src/clappform/_client.py
@@ -127,6 +127,7 @@ class Clappform:
                 endpoints=resolve_endpoints(self.cluster, endpoints),
                 credentials=self._credentials,
                 cluster=self.cluster,
+                cluster_discovered=self.cluster_discovered,
                 insecure=insecure,
                 default_timeout=timeout,
                 retries=retries,

--- a/src/clappform/_errors.py
+++ b/src/clappform/_errors.py
@@ -24,19 +24,24 @@ class ClappformError(Exception):
         status: str | None = None,
         method: str | None = None,
         cluster: str | None = None,
+        cluster_discovered: bool = False,
         location: str | None = None,
         details: str | None = None,
     ) -> None:
         self.status = status
         self.method = method
         self.cluster = cluster
+        self.cluster_discovered = cluster_discovered
         self.location = location
         self.details = details
         context = []
         if method:
             context.append(f"method={method}")
         if cluster is not None:
-            context.append(f"cluster={(cluster or 'main')!r}")
+            # Mark a DNS-discovered cluster so a wrong discovery is visible in
+            # the failure itself, not just in repr(client).
+            discovered = " (discovered)" if cluster_discovered else ""
+            context.append(f"cluster={(cluster or 'main')!r}{discovered}")
         if location:
             context.append(f"location={location!r}")
         if status:
@@ -106,6 +111,7 @@ def translate_rpc_error(
     *,
     method: str | None = None,
     cluster: str | None = None,
+    cluster_discovered: bool = False,
     location: str | None = None,
 ) -> ClappformError:
     """Map a grpc.RpcError onto the typed hierarchy, preserving call context."""
@@ -120,6 +126,7 @@ def translate_rpc_error(
             status=status_name,
             method=method,
             cluster=cluster,
+            cluster_discovered=cluster_discovered,
             location=location,
             details=details,
         )
@@ -136,6 +143,7 @@ def translate_rpc_error(
         status=status_name,
         method=method,
         cluster=cluster,
+        cluster_discovered=cluster_discovered,
         location=location,
         details=details,
     )

--- a/src/clappform/_transport.py
+++ b/src/clappform/_transport.py
@@ -131,6 +131,7 @@ class GrpcTransport:
     endpoints: dict[str, str]
     credentials: Credentials
     cluster: str
+    cluster_discovered: bool = False
     insecure: bool = False
     default_timeout: float | None = 60.0
     retries: RetryPolicy | None = DEFAULT_RETRIES
@@ -212,7 +213,12 @@ class GrpcTransport:
             "timeout": timeout if timeout is not None else self.default_timeout,
             "metadata": self._metadata(location, metadata),
         }
-        context = {"method": method, "cluster": self.cluster, "location": location}
+        context: dict[str, Any] = {
+            "method": method,
+            "cluster": self.cluster,
+            "cluster_discovered": self.cluster_discovered,
+            "location": location,
+        }
         try:
             result = multicallable(request, **call_kwargs)
         except grpc.RpcError as exc:

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -42,7 +42,13 @@ def test_snippets_directory_is_present() -> None:
     } <= found
 
 
-def test_quickstart_snippet_runs() -> None:
+def test_quickstart_snippet_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The quickstart leads with location-only construction, which discovers the
+    # cluster from DNS. CI has no such record, so stub the resolver; the snippet
+    # itself stays clean and reader-facing.
+    from clappform import _discovery
+
+    monkeypatch.setattr(_discovery, "discover_cluster", lambda location: "prod")
     module = _load("quickstart")
     module.run(module.build_mock())
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -72,6 +72,40 @@ def test_empty_cluster_reads_as_main() -> None:
     assert "cluster='main'" in str(error)
 
 
+def test_discovered_cluster_is_flagged_in_the_error() -> None:
+    # A DNS-discovered cluster is marked so a wrong discovery is visible in the
+    # failure itself, not only in repr(client).
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.NOT_FOUND, "x"),
+        cluster="prod-lts",
+        cluster_discovered=True,
+        location="acme",
+    )
+    assert "cluster='prod-lts' (discovered)" in str(error)
+    assert error.cluster_discovered is True
+
+
+def test_explicit_cluster_is_not_flagged_as_discovered() -> None:
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.NOT_FOUND, "x"),
+        cluster="prod-lts",
+        cluster_discovered=False,
+        location="acme",
+    )
+    assert "(discovered)" not in str(error)
+    assert error.cluster_discovered is False
+
+
+def test_discovered_main_cluster_reads_as_main_discovered() -> None:
+    error = translate_rpc_error(
+        FakeRpcError(grpc.StatusCode.NOT_FOUND, "x"),
+        cluster="",
+        cluster_discovered=True,
+        location="acme",
+    )
+    assert "cluster='main' (discovered)" in str(error)
+
+
 def test_missing_location_header_becomes_configuration_error() -> None:
     error = translate_rpc_error(
         FakeRpcError(grpc.StatusCode.ABORTED, "invalid/missing header: 'location'"),

--- a/tests/test_transport_grpc.py
+++ b/tests/test_transport_grpc.py
@@ -119,6 +119,31 @@ def test_not_found_translates(cf) -> None:
     assert "location='acme'" in str(excinfo.value)
 
 
+def test_discovered_cluster_flag_reaches_a_real_rpc_error(server, monkeypatch) -> None:
+    # When the cluster was discovered (no explicit cluster=), a real RPC failure
+    # carries the (discovered) marker end to end, so an operator seeing the
+    # error can tell a wrong discovery from a wrong explicit cluster.
+    from clappform import _discovery
+
+    address, _servicer = server
+    monkeypatch.setattr(_discovery, "discover_cluster", lambda location: "qa")
+    client = Clappform(
+        "acme",
+        api_key="test-key",
+        endpoints={"data": address},
+        insecure=True,
+        timeout=5.0,
+        retries=RetryPolicy(max_attempts=2),
+    )
+    try:
+        assert client.cluster_discovered is True
+        with pytest.raises(NotFoundError) as excinfo:
+            client.data.insert.insert_single(collection="missing")
+        assert "cluster='qa' (discovered)" in str(excinfo.value)
+    finally:
+        client.close()
+
+
 def test_missing_location_server_detail_becomes_configuration_error(cf) -> None:
     with pytest.raises(ConfigurationError, match="location="):
         cf.data.insert.insert_single(collection="no-tenant")


### PR DESCRIPTION
## Summary

Closes out the two remaining acceptance criteria on DNS-based cluster discovery; the core discovery path shipped earlier in #54.

- **Discovered cluster is now visible in RPC errors (AC5).** When the cluster was derived from DNS rather than passed explicitly, failures render it as `cluster='prod-lts' (discovered)`, so a wrong discovery is obvious in the error itself, not just in `repr(client)`. The flag threads client → transport error context → `ClappformError`, and is exposed as `error.cluster_discovered`. Explicit clusters stay unmarked.
- **Docs lead with location-only construction (AC7).** The landing example, README quickstart, and quickstart snippet now open with `Clappform(location=..., api_key=...)` (cluster discovered from DNS) and present explicit `cluster=` as the air-gapped / split-DNS override.

## Related issues

- Closes #53 — v6: DNS-based cluster discovery — derive cluster from the location's CNAME

## Tests

- `tests/test_errors.py` — the `(discovered)` marker and `cluster_discovered` attribute across a suffixed cluster, an explicit (unmarked) cluster, and a discovered main cluster.
- `tests/test_transport_grpc.py` — end-to-end: a client whose cluster was discovered drives a real `NOT_FOUND` through the in-process gRPC server and the error carries `cluster='qa' (discovered)`.
- `tests/test_docs_snippets.py` — stubs the resolver so the new location-only lead example runs hermetically in CI (no live DNS).
- `ruff check .`, `mypy src/clappform tools`, `pytest` all passing locally (263 passed, 3 pre-existing env-gated skips).

## Notes

- The remaining #53 acceptance criteria (constructor `cluster: str | None`, canonical-name parsing, fail-loud on lookup failure, per-instance cache + `with_location` re-discovery, and the resolver unit tests for main/suffixed/NXDOMAIN/musl-echo) were already delivered in #54 and are verified against the current code; this PR is only the two loose ends.
- Base branch is `Major/6`; `Closes #53` records intent but will not auto-close on merge into a non-default branch — the ticket is closed on merge.
