### PR TITLE
docs: guides + quickstart overhaul; reads take a pipeline (drop where/fields/limit sugar)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,7 +20,10 @@ generated from the `commons` protos, with:
   credentials)`, with namespaced sub-clients (`data`, `client`, `auth`,
   `notifier`).
 - First-class pandas DataFrame flows (`read` / `append` / `update` / `upsert` /
-  `replace_where` / `delete`) and saved-query reads.
+  `replace_where` / `delete`) and saved-query reads. Reads take an aggregation
+  `pipeline` (or none, for the whole collection); the client sends it verbatim
+  and never interprets a query language of its own. `aggregate(p)` is the
+  DataFrame-returning twin of `read(pipeline=p)`.
 - Native multi-cluster / multi-tenant support with optional DNS-based cluster
   discovery.
 - A typed error hierarchy that never leaks `grpc` to the caller.

--- a/docs/guides/actionflow-scripts.md
+++ b/docs/guides/actionflow-scripts.md
@@ -1,0 +1,55 @@
+# Running inside an actionflow
+
+Many scripts using this client don't run standalone — they run as tasks inside
+an actionflow, on a worker that hands the task its tenant, a key, and its input
+parameters. The client works the same way there as anywhere else; this guide
+covers the two things specific to that context.
+
+## Constructing the client in a worker
+
+The library reads nothing from the environment — `location`, the cluster, and
+the credential are always constructor arguments. So a task takes the values the
+worker exposes and passes them in explicitly:
+
+```python
+--8<-- "actionflow_scripts.py:connect-in-worker"
+```
+
+That keeps the client honest about where its configuration comes from: there's
+no hidden global state, no implicit env lookup, and the same code runs
+identically on your laptop against a test tenant. Omitting `cluster=` discovers
+it from the tenant's DNS record, which is usually what you want; pin it if the
+worker runs somewhere discovery can't reach.
+
+!!! note "Where the values come from is up to the worker"
+    Different worker setups expose the tenant and key differently (task
+    parameters, injected environment, a secrets helper). Whatever the source,
+    the client's contract is the same: hand it a `location` and an `api_key`.
+
+## Passing start parameters
+
+When a task starts another actionflow, it often needs to hand it parameters —
+a cursor, a date range, a batch id. Those ride on `custom_keys`, which today
+takes JSON bytes, so build them from a plain dict and encode once:
+
+```python
+--8<-- "actionflow_scripts.py:start-params"
+```
+
+The response carries the run's `uuid`, so a task can start a flow and record or
+return the id it kicked off.
+
+## Everything else is the ordinary loop
+
+Nothing about running in a worker changes how you read and write data — it's
+the same DataFrame surface as the [Quickstart](../quickstart.md) and
+[Cookbook](cookbook.md):
+
+```python
+--8<-- "actionflow_scripts.py:read-write"
+```
+
+See [Actionflows & listings](actionflows-and-listings.md) for listing and
+inspecting flows and their tasks, and [Error handling & retries](errors-and-retries.md)
+for turning failures into the typed exceptions a task can branch on.
+```

--- a/docs/guides/actionflows-and-listings.md
+++ b/docs/guides/actionflows-and-listings.md
@@ -14,7 +14,9 @@ one you've seen them all.
 Trigger an actionflow by id. The response carries the run's `uuid`, so you can
 correlate the run with the tasks it spawns or surface it to a caller. Pass
 `user_id=` to attribute the run, or `custom_keys=` (JSON bytes) to hand it
-start parameters.
+start parameters — see
+[Passing start parameters](actionflow-scripts.md#passing-start-parameters) for
+how to build them from a dict.
 
 ```python
 --8<-- "client_operations.py:start-actionflow"

--- a/docs/guides/cookbook.md
+++ b/docs/guides/cookbook.md
@@ -1,0 +1,160 @@
+# Cookbook
+
+Copy-paste recipes for the tasks people write most. Every block here runs
+against `LocalMock` in CI, so the code is known-good — lift it straight into
+your script and swap the collection names and filters for yours.
+
+For the full argument list behind any call, see [DataFrame flows](dataframes.md)
+(the collection surface) and the [API families reference](../reference/api-families.md)
+(everything on `cf.client` / `cf.data`).
+
+## Collection CRUD
+
+The four operations you'll use most, on a `cf.data.collection(ref)` handle.
+`ref` is a slug or a UUID — a slug is resolved once and cached per tenant.
+
+### Create (insert new rows)
+
+```python
+--8<-- "cookbook.py:crud-create"
+```
+
+### Read (filter into a DataFrame)
+
+```python
+--8<-- "cookbook.py:crud-read"
+```
+
+### Update (write changes back)
+
+```python
+--8<-- "cookbook.py:crud-update"
+```
+
+### Upsert (insert-or-update on a business key)
+
+```python
+--8<-- "cookbook.py:crud-upsert"
+```
+
+### Delete
+
+```python
+--8<-- "cookbook.py:crud-delete"
+```
+
+!!! warning "Full wipes are explicit"
+    `delete(where={})` is refused — an empty filter matching every document is
+    almost always a bug. To empty a collection on purpose, call `clear()`.
+
+## Read a single record
+
+Filter, cap at one row, and take it as a dict — with an `.empty` guard so a
+miss returns `None` instead of raising.
+
+```python
+--8<-- "cookbook.py:single-read"
+```
+
+## Load a file into a collection
+
+Read the bytes into a DataFrame with pandas, then `append()`.
+
+```python
+--8<-- "cookbook.py:ingest-file"
+```
+
+pandas picks the reader from the format — `read_csv`, `read_excel` (needs
+`openpyxl`), `read_parquet`, `read_json`. The client chunks and streams the
+upload; `append()` returns the number of rows written. For a full refresh of
+existing rows, use `upsert(df, on="...")` instead so a re-run updates in place.
+
+## Aggregate a collection into a DataFrame
+
+Group, sort, or reshape server-side and get a frame back.
+
+```python
+--8<-- "cookbook.py:aggregate-to-df"
+```
+
+`aggregate(p)` is exactly `read(pipeline=p)` returning a DataFrame — use
+whichever name reads better at the call site. A plain filter/projection is just
+a pipeline with a `$match`/`$project` stage (see the read recipe above); reach
+for the `aggregate()` name when the call is conceptually a grouping or reshape.
+
+## Handle an empty result
+
+A read matching nothing returns an empty DataFrame — never an error, never
+`None`. It has no columns, so branch on `.empty` before indexing one.
+
+```python
+--8<-- "cookbook.py:empty-read"
+```
+
+## Write a change-request record
+
+A change request is a row in its own collection.
+
+```python
+--8<-- "cookbook.py:change-request"
+```
+
+To amend an existing change-request row, keep its `_id` and call `update()`, or
+match on your own identifier with `upsert(df, on="cf_original_id")`.
+
+## Start an actionflow
+
+Trigger a flow by id; the response carries the run's `uuid`.
+
+```python
+--8<-- "cookbook.py:actionflow-start"
+```
+
+To hand the flow start parameters, pass `custom_keys=` — JSON bytes today, so
+encode a dict:
+
+```python
+--8<-- "cookbook.py:actionflow-params"
+```
+
+More on the in-worker context in
+[Running inside an actionflow](actionflow-scripts.md), and on listing/inspecting
+flows in [Actionflows & listings](actionflows-and-listings.md).
+
+## Manage indexes
+
+Create, list, and drop indexes on a collection through `cf.data.index`.
+
+```python
+--8<-- "cookbook.py:index"
+```
+
+`create()` also takes a `mongo_index_model=` (for compound or option-bearing
+indexes) or `elastic_settings=` for Elastic-backed collections; passing just
+`index_name` builds a simple single-field index.
+
+## Move an app between instances
+
+Export an app bundle from the source instance and import it into the
+destination. Each part (`app`, `queries`, `actionflows`, `questionnaires`) is
+bytes, so it passes straight through.
+
+```python
+--8<-- "cookbook.py:transfer"
+```
+
+Choose what travels with the `include_*` flags on `export_app`, and set
+`overwrite=` on `import_app` to control clobbering an existing app.
+
+## Copy data across clusters
+
+Two clients are two clusters in one process. Read from one and `upsert()` into
+the other on a business key so re-runs never duplicate.
+
+```python
+--8<-- "cookbook.py:cross-cluster"
+```
+
+See [Multi-cluster & multi-tenant](multi-cluster.md) for sharing connections
+across tenants on the same cluster.
+```

--- a/docs/guides/dataframes.md
+++ b/docs/guides/dataframes.md
@@ -10,31 +10,42 @@ Get one from `cf.data.collection(ref)`, where `ref` is a slug or a UUID
 
 ## Read into a DataFrame
 
-`read()` streams the collection (or a filtered slice) into pandas. `where`,
-`fields` and `limit` are client-side sugar compiled into a
-`$match` / `$project` / `$limit` pipeline — the API never sees the kwargs.
+`read()` with no arguments streams the whole collection into pandas. To filter,
+project, or reshape, pass an aggregation `pipeline` — the client sends it to the
+server untouched, so use the syntax the collection's backend expects (Mongo
+stages for a Mongo-backed collection, Elastic DSL for an Elastic-backed one).
 
 ```python
 --8<-- "dataframes.py:read"
 ```
 
 `_id` is kept as a column so the frame round-trips through `update()`. An empty
-result yields an empty frame, never an error.
+result yields an empty frame, never an error — but that frame has no columns, so
+branch on `df.empty` before indexing a column. See
+[Handle an empty result](cookbook.md#handle-an-empty-result).
 
-### Aggregation the sugar doesn't cover
+!!! note "No client-side query language"
+    The pipeline is passed through verbatim — the client neither interprets nor
+    rewrites your stages. There is one read idiom (a pipeline), so there is
+    nothing to remember about which operators are "supported": whatever the
+    server understands, you can send.
 
-For stages `where` / `fields` / `limit` don't emit — `$group`, `$sort`, or an
-Elastic-backed collection's DSL — pass a full pipeline with `aggregate()`. The
-list of stages is sent to the server untouched and the result comes back as a
-DataFrame (one row per group here).
+### Grouping and reshaping with `aggregate()`
+
+`aggregate()` is the DataFrame-returning twin of `read(pipeline=...)` — reach
+for it when a call is conceptually an aggregation (`$group`, `$sort`, `$lookup`)
+rather than a filtered read. The stages are sent to the server untouched and the
+result comes back as a DataFrame (one row per group here).
 
 ```python
 --8<-- "dataframes.py:aggregate"
 ```
 
-If you want the records or memory-bounded batches instead of a frame, call
-`fetch(pipeline=[...])` and iterate the [`ReadResult`][clappform.ReadResult]
-rather than `aggregate()`.
+`read(pipeline=...)`, `fetch(pipeline=...)` and `aggregate(...)` put the
+identical pipeline on the wire — they differ only in what they hand back
+(a DataFrame, a [`ReadResult`][clappform.ReadResult], and a DataFrame
+respectively). Use `fetch()` when you want records or memory-bounded batches
+instead of a materialised frame.
 
 ### Aggregation via a saved query
 

--- a/docs/guides/migrating.md
+++ b/docs/guides/migrating.md
@@ -1,0 +1,186 @@
+# Migrating from 4.x / 5.x
+
+Version 6 is a ground-up rewrite. If your scripts import `clappform.Data`,
+`clappform.Client`, or anything from `clappform.proto.*`, they are on the old
+package. This guide shows the v6 way for every common call, with the old form
+kept underneath purely as a memory jog.
+
+The short version: the raw protobuf request objects, the manual
+`json.dumps(...).encode("utf-8")` around pipelines and payloads, the
+`pd.concat([pd.DataFrame(json.loads(x.data)) for x in ...])` read loop, and the
+separate `Data` / `Client` objects are all gone. You work with a single
+`Clappform` client and pandas DataFrames.
+
+!!! note "How to read this page"
+    The **v6** code in each section is what you write now, and it is pulled from
+    a snippet that runs against `LocalMock` in CI — so it is guaranteed to work.
+    The **old 4.x / 5.x** form is tucked into a collapsed "reference" block below
+    each one; open it only if you need to recognise what you're replacing.
+
+## Connecting
+
+There were two client classes — `Data` and `Client` — each taking a token, a
+location, and often an explicit `target` host:port. v6 has one client, and the
+cluster is discovered from DNS.
+
+```python
+--8<-- "migrating.py:connect"
+```
+
+Data-plane calls that were on `Data` now live on `cf.data`; the ones on
+`Client` live on `cf.client`. If you talk to an older cluster that still serves
+gRPC on `:50051`, pass it through `endpoints=` (see
+[Multi-cluster](multi-cluster.md)) — discovery targets the current clusters on
+443.
+
+??? note "Old (4.x / 5.x) — reference"
+
+    ```python
+    import clappform
+
+    d = clappform.Data(token=TOKEN, location=LOCATION, target="data-test.clappform.com:50051")
+    c = clappform.Client(token=TOKEN, location=LOCATION)
+    ```
+
+## Reading a collection
+
+`read()` collapses the request object, the hand-encoded pipeline, and the
+`pd.concat` over streamed chunks into one call that returns a DataFrame.
+
+```python
+--8<-- "migrating.py:read"
+```
+
+??? note "Old — reference"
+
+    ```python
+    from clappform.proto.clappform.data.v1 import aggregate_pb2
+
+    request = aggregate_pb2.AggregateStreamRequest(
+        pipeline=json.dumps([{"$match": {"status": "open"}}]).encode("utf-8"),
+        collection=COLLECTION,
+    )
+    df = pd.concat(
+        [pd.DataFrame(json.loads(x.data)) for x in d.aggregate(request)],
+        ignore_index=True,
+    )
+    ```
+
+If you had a full pipeline (`$group`, `$sort`, …) rather than a simple filter,
+pass it to `aggregate()` — still no `json.dumps`, no `encode()`, no manual
+concat:
+
+```python
+--8<-- "migrating.py:aggregate"
+```
+
+## Inserting rows
+
+`append()` chunks and streams the upload for you and returns the number of rows
+written — no `insert_many_dataframe` helper, no draining the response iterator.
+
+```python
+--8<-- "migrating.py:insert"
+```
+
+??? note "Old — reference"
+
+    ```python
+    from clappform.utils import insert_many_dataframe
+
+    request = insert_many_dataframe(collection, df, size=100)
+    list(client.insert_many(request))
+    ```
+
+## Updating rows
+
+`read()` keeps `_id` on the frame, so you mutate and hand it straight back —
+no batching, no per-batch JSON serialisation, no `UpdateRequestByOid`.
+
+```python
+--8<-- "migrating.py:update"
+```
+
+??? note "Old — reference"
+
+    ```python
+    for start in range(0, len(df), batch_size):
+        batch = df.iloc[start:start + batch_size]
+        request = update_pb2.UpdateRequestByOid(
+            data=batch.to_json(orient="records").encode("utf-8"),
+            collection=collection,
+        )
+        d.update_replace_many(request)
+    ```
+
+## Deleting rows
+
+`delete()` takes exactly one of `oids=` (specific `_id`s) or `where=` (a
+filter). An empty `where` is refused — use `clear()` for a deliberate full wipe.
+
+```python
+--8<-- "migrating.py:delete"
+```
+
+??? note "Old — reference"
+
+    ```python
+    from clappform.proto.clappform.data.v1 import delete_pb2
+
+    request = delete_pb2.DeleteRequestOids(oids=ids, collection=collection)
+    d.delete_many_by_oids(request)
+    ```
+
+## Starting an actionflow
+
+`start()` takes an id on the same client — no raw `StartActionflow` proto, no
+integer `actionflowid`, no magic `user=` number.
+
+```python
+--8<-- "migrating.py:actionflow"
+```
+
+To pass start parameters, use `custom_keys=` — today that field takes JSON
+bytes, so build it with `json.dumps({...}).encode("utf-8")`. See
+[Running inside an actionflow](actionflow-scripts.md#passing-start-parameters).
+
+??? note "Old — reference"
+
+    ```python
+    from clappform.proto.clappform.client.v1 import actionflow_pb2
+
+    request = actionflow_pb2.StartActionflow(
+        actionflowid=ACTIONFLOW_ID,
+        user=4,
+        settings=json.dumps({"custom_keys": {"next_page": NEXT_PAGE}}),
+    )
+    c.actionflow_start(request)
+    ```
+
+## Mapping table
+
+| You had (4.x / 5.x) | You now write (6.x) |
+| --- | --- |
+| `clappform.Data(token, location, target=...)` | `Clappform(location=..., api_key=...)` → `cf.data` |
+| `clappform.Client(token, location)` | the same client → `cf.client` |
+| `d.aggregate(AggregateStreamRequest(...))` + `pd.concat(...)` | `cf.data.collection(ref).read(...)` / `.aggregate([...])` |
+| `insert_many_dataframe(...)` + `insert_many(...)` | `cf.data.collection(ref).append(df)` |
+| `update_replace_many(UpdateRequestByOid(...))` | `cf.data.collection(ref).update(df)` |
+| `delete_many_by_oids(DeleteRequestOids(...))` | `cf.data.collection(ref).delete(oids=[...])` |
+| `c.actionflow_start(StartActionflow(...))` | `cf.client.actionflow.start(id=...)` |
+| `from clappform.proto...import *_pb2` | not needed — but `clappform.gen...` is there if you want the raw stubs |
+| manual `json.dumps(pipeline).encode()` | pass Python dicts/lists; the client encodes |
+| `try/except grpc.RpcError` | `except ClappformError` (see [Errors](errors-and-retries.md)) |
+
+## Things that moved out of scope
+
+- **HTTP fallback.** The old scripts sometimes hit `client.clappform.com/api/v1`
+  with `requests` for endpoints the gRPC client didn't wrap (questionnaires,
+  the message API). v6 is gRPC-first; if an operation isn't on a sub-client yet,
+  reach for the generated stub under `clappform.gen...` rather than raw HTTP.
+- **`target="...:50051"`.** Discovery targets current clusters on 443. Legacy
+  `:50051` hosts are reachable via an explicit `endpoints=` override.
+
+Next: the [Cookbook](cookbook.md) for the recipes these building blocks compose
+into.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ from clappform import Clappform
 
 # The cluster is discovered from DNS — location and an API key are all you need.
 cf = Clappform(location="acme", api_key="cf_live_...")
-df = cf.data.collection("sales_orders").read(where={"status": "open"})
+df = cf.data.collection("sales_orders").read(pipeline=[{"$match": {"status": "open"}}])
 ```
 
 ## What this client is

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,11 @@
 # Quickstart
 
-Install, connect, and round-trip a DataFrame in about twenty lines.
+Install, connect, and round-trip a DataFrame in about twenty lines — then see
+the shape almost every real task takes.
+
+Coming from the 4.x or 5.x package? Start with the
+[Migrating from 4.x / 5.x](guides/migrating.md) guide instead — it maps every
+old call to its v6 equivalent.
 
 ## Install
 
@@ -26,8 +31,13 @@ main cluster). Omit it and the client discovers it from the DNS record of
 setups. `location` is your tenant subdomain and is sent as metadata on every
 call.
 
-API keys are the only credential v6 ships. Keep the key out of source — read it
-from your own secret store and pass it in.
+API keys are the only credential v6 ships. Keep the key out of source — the
+library never reads the environment for you, so pull it from your own secret
+store and pass it in:
+
+```python
+--8<-- "quickstart.py:connect-env"
+```
 
 ## Read, mutate, write back
 
@@ -39,13 +49,56 @@ That is the whole loop: `read()` gives you a pandas DataFrame with `_id` kept as
 a column, you change it with plain pandas, and `update()` writes the changed
 rows back — matched on `_id` by default, so the common case needs no arguments.
 
+!!! tip "Slugs and UUIDs both work"
+    `cf.data.collection("sales_orders")` takes a slug or a UUID. A slug is
+    resolved to its id once and cached per tenant, so you never paste UUIDs into
+    a script to save a lookup.
+
+## A complete task, end to end
+
+Almost every job has the same shape: connect, read a slice, transform it with
+plain pandas, write it back, and often kick off a downstream flow. Here is the
+whole thing — this is what a real script looks like once the boilerplate is
+gone.
+
+```python
+--8<-- "quickstart.py:full-task"
+```
+
+Running it prints:
+
+```text
+pulled 2 open orders
+started run run-abc123
+```
+
+No request objects, no `json.dumps(...).encode()`, no manual pagination, no
+`grpc` imports — the client absorbs all of it.
+
+## What you just did
+
+- **Connected** with one `(cluster, location, credential)` binding — nothing
+  global, so two clusters or tenants can coexist in one process.
+- **Read** a filtered slice straight into pandas over a streaming RPC.
+- **Wrote** the changed rows back, matched on `_id`.
+- **Started** a second-API call (the Client API) through the same client.
+- **Stayed typed** — any failure would have raised a `ClappformError`
+  subclass carrying the cluster and tenant, never a raw `grpc.RpcError`.
+
 ## Next steps
 
+- [Migrating from 4.x / 5.x](guides/migrating.md) — old call → new call, for
+  every operation the previous package had.
+- [Cookbook](guides/cookbook.md) — copy-paste recipes for the tasks people
+  write most: file ingest, aggregation, change requests, cross-cluster copy.
 - [DataFrame flows](guides/dataframes.md) — filtering, batching, append /
   upsert, server-side updates and deletes.
+- [Running inside an actionflow](guides/actionflow-scripts.md) — the in-worker
+  context: where `location` and the key come from, and passing start parameters.
 - [Multi-cluster & multi-tenant](guides/multi-cluster.md) — several clusters
   and tenants in one process.
 - [Error handling & retries](guides/errors-and-retries.md) — the typed error
   hierarchy and retry configuration.
 - [Testing with LocalMock](guides/testing.md) — run your pipelines with no
   infrastructure.
+```

--- a/docs/snippets/actionflow_scripts.py
+++ b/docs/snippets/actionflow_scripts.py
@@ -1,0 +1,70 @@
+"""Runnable source for the "running inside an actionflow" guide snippets.
+
+Covers the in-worker context: constructing a client from values the worker
+supplies, and passing start parameters to a flow. Only the shipped v6 API is
+used here. Runs against ``LocalMock`` in the docs-test job.
+"""
+
+from __future__ import annotations
+
+import json
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+
+    mock = LocalMock()
+    mock.seed_collection_slug("sales_orders", id="sales_orders-id")
+    mock.seed("sales_orders-id", [{"order_id": "A-1", "amount": 10.0, "status": "open"}])
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="run-xyz"),
+    )
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    from clappform import Clappform
+
+    # In a real worker these come from the task's environment/parameters. We set
+    # them as plain locals here so the snippet is self-contained.
+    TENANT = "acme"
+    API_KEY = "cf_live_..."
+
+    # --8<-- [start:connect-in-worker]
+    # A task running in the worker is handed its tenant and a key. Nothing is
+    # read from the environment by the library — you pass them in, so pull them
+    # from wherever the worker exposes them and construct the client explicitly.
+    cf = Clappform(location=TENANT, api_key=API_KEY)
+    # --8<-- [end:connect-in-worker]
+
+    cf = Clappform(location=TENANT, cluster="prod", api_key=API_KEY, transport=transport)
+
+    with cf:
+        # --8<-- [start:start-params]
+        # Start parameters ride on `custom_keys`, which today takes JSON bytes.
+        # Build them from a plain dict — encode once, pass through.
+        custom_keys = json.dumps({"next_page": "", "since": "2026-01-01"}).encode("utf-8")
+        started = cf.client.actionflow.start(
+            id="recalculate-dashboards",
+            custom_keys=custom_keys,
+        )
+        run_id = started.uuid
+        # --8<-- [end:start-params]
+        assert run_id == "run-xyz"
+
+        # --8<-- [start:read-write]
+        # From there it's the ordinary DataFrame loop — nothing about running in
+        # a worker changes how you read and write collections.
+        orders = cf.data.collection("sales_orders")
+        df = orders.read(pipeline=[{"$match": {"status": "open"}}])
+        df["amount"] = df["amount"] * 1.1
+        orders.update(df)
+        # --8<-- [end:read-write]
+        assert len(df) == 1
+
+
+if __name__ == "__main__":
+    run(build_mock())

--- a/docs/snippets/cookbook.py
+++ b/docs/snippets/cookbook.py
@@ -1,0 +1,298 @@
+"""Runnable source for the cookbook guide snippets.
+
+Copy-paste recipes for the operations users reach for most: collection CRUD,
+single-record reads, file ingest, aggregation, actionflow starts, index
+management, and app transfer. Every block is pulled into docs/guides/cookbook.md
+and runs against ``LocalMock`` in the docs-test job, so the recipes stay
+correct.
+
+Data-plane calls (read/append/update/delete/aggregate) run against the seeded
+store. Everything else — actionflow start, index management, transfer — is not a
+data-plane RPC, so it is backed by an explicit ``.on()`` stub keyed on the full
+gRPC method path, exactly as you'd stub it in your own tests.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pandas as pd
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+    from clappform.gen.clappform.client.v1.transfer import transfer_pb2
+    from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+    from clappform.gen.clappform.data.v1.index import index_pb2
+    from clappform.gen.clappform.v1.commons import commons_pb2
+    from clappform.testing import _local_mock
+
+    mock = LocalMock()
+    mock.seed_collection_slug("housing_stock", id="housing_stock-id")
+    mock.seed(
+        "housing_stock-id",
+        [
+            {"address": "Herengracht 1", "city": "Amsterdam", "energy_label": "C"},
+            {"address": "Keizersgracht 42", "city": "Amsterdam", "energy_label": "F"},
+        ],
+    )
+    for slug in ("import_target", "change_requests", "empty_coll", "customers"):
+        mock.seed_collection_slug(slug, id=f"{slug}-id")
+        mock.seed(f"{slug}-id", [])
+    # one seeded customer for the single-record read recipe
+    mock.seed("customers-id", [{"email": "a@example.com", "plan": "pro", "seats": 3}])
+
+    # $group isn't computed by the seeded double; stub the server's grouped
+    # answer for that pipeline and delegate every other read to the built-in.
+    def _aggregate(request):
+        stages = json.loads(request.pipeline) if request.pipeline else []
+        if any("$group" in s for s in stages):
+            grouped = [{"_id": "C", "count": 1}, {"_id": "F", "count": 1}]
+            return [aggregate_pb2.AggregateResponse(data=json.dumps(grouped).encode())]
+        return _local_mock._handle_aggregate_stream(
+            mock, "unary_stream", request, aggregate_pb2.AggregateResponse
+        )
+
+    mock.on("/clappform.data.v1.aggregate.AggregateManagement/AggregateStream", _aggregate)
+
+    # Non-data-plane RPCs the recipes call.
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="run-xyz"),
+    )
+    mock.on(
+        "/clappform.data.v1.index.IndexManagement/Create",
+        index_pb2.CreateIndexResponse(success=True),
+    )
+    mock.on(
+        "/clappform.data.v1.index.IndexManagement/GetAll",
+        index_pb2.ListIndexesResponse(
+            indexes=[index_pb2.IndexInfo(name="_id_"), index_pb2.IndexInfo(name="city_1")]
+        ),
+    )
+    mock.on(
+        "/clappform.data.v1.index.IndexManagement/Delete",
+        index_pb2.DeleteIndexResponse(success=True),
+    )
+    mock.on(
+        "/clappform.client.v1.transfer.TransferManagement/ExportApp",
+        transfer_pb2.AppExport(app=b'{"slug":"sales"}', queries=b"[]", actionflows=b"[]"),
+    )
+    mock.on(
+        "/clappform.client.v1.transfer.TransferManagement/ImportApp",
+        commons_pb2.Message(message="imported"),
+    )
+    return mock
+
+
+def build_second_cluster_mock() -> LocalMock:
+    mock = LocalMock()
+    mock.seed_collection_slug("housing_stock", id="housing_stock-id")
+    mock.seed("housing_stock-id", [])
+    # the transfer recipe imports into this second client
+    from clappform.gen.clappform.v1.commons import commons_pb2
+
+    mock.on(
+        "/clappform.client.v1.transfer.TransferManagement/ImportApp",
+        commons_pb2.Message(message="imported"),
+    )
+    return mock
+
+
+def run(transport: LocalMock, other_cluster: LocalMock) -> None:
+    from clappform import Clappform
+
+    cf = Clappform(
+        location="acme", cluster="prod", api_key="cf_live_...", transport=transport
+    )
+
+    with cf:
+        # ---- Collection CRUD ------------------------------------------------
+        # --8<-- [start:crud-create]
+        # CREATE — append new documents from a DataFrame. Returns rows written.
+        rows = pd.DataFrame(
+            [
+                {"address": "Prinsengracht 3", "city": "Amsterdam", "energy_label": "B"},
+                {"address": "Damrak 70", "city": "Amsterdam", "energy_label": "A"},
+            ]
+        )
+        cf.data.collection("housing_stock").append(rows)
+        # --8<-- [end:crud-create]
+
+        # --8<-- [start:crud-read]
+        # READ — a filtered slice straight into pandas. `where` filters,
+        # `fields` projects, `limit` caps; all optional.
+        df = cf.data.collection("housing_stock").read(
+            pipeline=[
+                {"$match": {"city": "Amsterdam"}},
+                {"$project": {"address": 1, "energy_label": 1}},
+                {"$limit": 1000},
+            ]
+        )
+        # --8<-- [end:crud-read]
+        assert len(df) >= 2
+
+        # --8<-- [start:crud-update]
+        # UPDATE — mutate the frame (which still carries _id) and hand it back.
+        # Matched on _id by default, so no key argument is needed.
+        df = cf.data.collection("housing_stock").read(
+            pipeline=[{"$match": {"city": "Amsterdam"}}]
+        )
+        df["needs_audit"] = df["energy_label"].isin(["F", "G"])
+        cf.data.collection("housing_stock").update(df)
+        # --8<-- [end:crud-update]
+
+        # --8<-- [start:crud-upsert]
+        # UPSERT — insert-or-update keyed on a business column. Re-running never
+        # duplicates: rows whose key exists are updated, the rest inserted.
+        cf.data.collection("housing_stock").upsert(rows, on="address")
+        # --8<-- [end:crud-upsert]
+
+        # --8<-- [start:crud-delete]
+        # DELETE — by explicit _id(s) or by a server-side filter.
+        housing = cf.data.collection("housing_stock")
+        housing.delete(where={"energy_label": "G"})     # by filter
+        housing.delete(oids=["some-id-1", "some-id-2"])  # by id
+        # To wipe the whole collection, call clear() — never delete(where={}).
+        # --8<-- [end:crud-delete]
+
+        # ---- Single-record read --------------------------------------------
+        # --8<-- [start:single-read]
+        # Fetch one document: $match filters, $limit caps at one row, then take
+        # it as a dict.
+        df = cf.data.collection("customers").read(
+            pipeline=[{"$match": {"email": "a@example.com"}}, {"$limit": 1}]
+        )
+        customer = df.iloc[0].to_dict() if not df.empty else None
+        # --8<-- [end:single-read]
+        assert customer is not None and customer["plan"] == "pro"
+
+        # ---- File ingest ----------------------------------------------------
+        # --8<-- [start:ingest-file]
+        # Load an uploaded file (bytes) into a DataFrame, then append it. Swap
+        # read_csv for the reader matching the source:
+        #   .xlsx    -> pd.read_excel(io.BytesIO(file_bytes))   # needs openpyxl
+        #   .parquet -> pd.read_parquet(io.BytesIO(file_bytes))
+        #   .json    -> pd.read_json(io.BytesIO(file_bytes))
+        loaded = pd.read_csv(io.BytesIO(file_bytes))
+        written = cf.data.collection("import_target").append(loaded)
+        # --8<-- [end:ingest-file]
+        assert written == 2
+
+        # ---- Aggregate to a DataFrame --------------------------------------
+        # --8<-- [start:aggregate-to-df]
+        # Group server-side and get a DataFrame back — one result row per group.
+        by_label = cf.data.collection("housing_stock").aggregate(
+            [{"$group": {"_id": "$energy_label", "count": {"$sum": 1}}}]
+        )
+        # --8<-- [end:aggregate-to-df]
+        assert "count" in by_label.columns
+
+        # ---- Empty result --------------------------------------------------
+        # --8<-- [start:empty-read]
+        # A read matching nothing returns an empty frame (no columns), never an
+        # error — so branch on .empty before indexing a column.
+        df = cf.data.collection("empty_coll").read(
+            pipeline=[{"$match": {"status": "open"}}]
+        )
+        if df.empty:
+            print("nothing to process")
+        else:
+            df["processed"] = True
+            cf.data.collection("empty_coll").update(df)
+        # --8<-- [end:empty-read]
+        assert df.empty
+
+        # ---- Change request ------------------------------------------------
+        # --8<-- [start:change-request]
+        # A change request is a row in its collection: build a dict, wrap it in
+        # a one-row frame, append.
+        record = {
+            "cf_original_id": "obj-123",
+            "status": "requested",
+            "changes": [{"key": "energy_label", "old": "F", "new": "C"}],
+        }
+        cf.data.collection("change_requests").append(pd.DataFrame([record]))
+        # --8<-- [end:change-request]
+
+        # ---- Actionflow start ----------------------------------------------
+        # --8<-- [start:actionflow-start]
+        # Trigger a flow by id; the response carries the run's uuid.
+        started = cf.client.actionflow.start(id="recalculate-dashboards")
+        run_id = started.uuid
+        # --8<-- [end:actionflow-start]
+        assert run_id == "run-xyz"
+
+        # --8<-- [start:actionflow-params]
+        # With start parameters — custom_keys takes JSON bytes today, so encode
+        # a plain dict.
+        cf.client.actionflow.start(
+            id="recalculate-dashboards",
+            custom_keys=json.dumps({"since": "2026-01-01"}).encode("utf-8"),
+        )
+        # --8<-- [end:actionflow-params]
+
+        # ---- Index management ----------------------------------------------
+        # --8<-- [start:index]
+        # Create an index on a collection, list what's there, drop one.
+        cf.data.index.create(collection="housing_stock", index_name="city_1")
+
+        indexes = [ix.name for ix in cf.data.index.get_all(collection="housing_stock").indexes]
+
+        cf.data.index.delete(collection="housing_stock", index_name="city_1")
+        # --8<-- [end:index]
+        assert "city_1" in indexes
+
+    # ---- App transfer between instances ------------------------------------
+    # --8<-- [start:transfer]
+    # Move a whole app from one instance to another: export from the source,
+    # import into the destination. Each part is bytes, so it passes straight
+    # through — no unpacking.
+    src = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+    dst = Clappform(location="acme", cluster="qa", api_key="cf_test_...", transport=other_cluster)
+
+    with src, dst:
+        bundle = src.client.transfer.export_app(
+            id="sales", include_app=True, include_queries=True, include_actionflows=True
+        )
+        dst.client.transfer.import_app(
+            app=bundle.app,
+            queries=bundle.queries,
+            actionflows=bundle.actionflows,
+            overwrite=False,
+        )
+    # --8<-- [end:transfer]
+
+    # ---- Cross-cluster data copy -------------------------------------------
+    # --8<-- [start:cross-cluster]
+    # Two clients = two clusters in one process. Read from one, upsert into the
+    # other on a business key so re-runs never duplicate.
+    prod = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
+    qa = Clappform(location="acme", cluster="qa", api_key="cf_test_...", transport=other_cluster)
+
+    with prod, qa:
+        data = prod.data.collection("housing_stock").read()
+        qa.data.collection("housing_stock").upsert(data, on="address")
+    # --8<-- [end:cross-cluster]
+
+
+# A tiny CSV built in-memory so the ingest recipe runs in CI without a fixture
+# file on disk and without an optional file-format dependency. Readers
+# substitute their own file bytes (and reader) for the real source.
+def _sample_csv() -> bytes:
+    return pd.DataFrame(
+        [
+            {"address": "Prinsengracht 3", "city": "Amsterdam", "energy_label": "B"},
+            {"address": "Damrak 70", "city": "Amsterdam", "energy_label": "A"},
+        ]
+    ).to_csv(index=False).encode("utf-8")
+
+
+file_bytes = _sample_csv()
+
+
+if __name__ == "__main__":
+    run(build_mock(), build_second_cluster_mock())

--- a/docs/snippets/dataframes.py
+++ b/docs/snippets/dataframes.py
@@ -33,20 +33,24 @@ def run(transport: LocalMock) -> None:
         # --8<-- [start:read]
         orders = cf.data.collection("sales_orders")
 
-        # `where`, `fields` and `limit` are client-side sugar compiled into a
-        # $match / $project / $limit pipeline — the API never sees the kwargs.
+        # read() with no arguments streams the whole collection. To filter,
+        # project or cap, pass an aggregation pipeline — it is sent to the
+        # server untouched, so use the syntax the collection's backend expects
+        # (Mongo stages here).
         df = orders.read(
-            where={"status": "open"},
-            fields=["order_id", "amount", "region"],
-            limit=1000,
+            pipeline=[
+                {"$match": {"status": "open"}},
+                {"$project": {"order_id": 1, "amount": 1, "region": 1}},
+                {"$limit": 1000},
+            ]
         )
         # --8<-- [end:read]
         assert len(df) == 2
 
         # --8<-- [start:aggregate]
-        # For stages the sugar does not emit ($group, $sort, ...) pass a full
-        # pipeline to aggregate(). It is sent to the server untouched and the
-        # result comes back as a DataFrame — one row per group here.
+        # aggregate() is the DataFrame-returning twin of read(pipeline=...).
+        # Reach for it for grouping/reshaping stages ($group, $sort, ...). The
+        # pipeline is sent to the server untouched — one row per group here.
         revenue_by_region = orders.aggregate(
             [
                 {"$match": {"status": "open"}},
@@ -74,7 +78,9 @@ def run(transport: LocalMock) -> None:
         # --8<-- [start:batches]
         # Memory-bounded reads: one list of records per gRPC chunk, nothing
         # fully materialised. Ask the server to cap each chunk with batch_size.
-        for batch in orders.iter_batches(where={"status": "open"}, batch_size=500):
+        for batch in orders.iter_batches(
+            pipeline=[{"$match": {"status": "open"}}], batch_size=500
+        ):
             handle(batch)
         # --8<-- [end:batches]
 
@@ -97,7 +103,7 @@ def run(transport: LocalMock) -> None:
         # read -> mutate -> write-back. update() keys on _id by default, which
         # read() keeps as a column, so the round-trip needs no `on=`. Only the
         # rows you changed are sent.
-        open_orders = orders.read(where={"status": "open"})
+        open_orders = orders.read(pipeline=[{"$match": {"status": "open"}}])
         open_orders["amount"] = open_orders["amount"] * 1.08  # 8% uplift
         orders.update(open_orders)
         # --8<-- [end:update]
@@ -126,7 +132,7 @@ def run(transport: LocalMock) -> None:
         orders.delete(where={"status": "closed"})
 
         # Delete specific rows by their _id instead of a filter.
-        stale = orders.read(where={"region": "APAC"})
+        stale = orders.read(pipeline=[{"$match": {"region": "APAC"}}])
         orders.delete(oids=list(stale["_id"]))
         # --8<-- [end:server-side]
         assert not any(row.get("region") == "APAC" for row in transport.records("sales_orders-id"))

--- a/docs/snippets/migrating.py
+++ b/docs/snippets/migrating.py
@@ -1,0 +1,131 @@
+"""Runnable source for the migration guide snippets.
+
+The guide shows old 4.x/5.x code beside its v6 replacement. The *old* blocks are
+illustrative only (that package isn't installed here), so they live in the
+guide as plain fenced code. Every *v6* block is pulled from this file and runs
+against ``LocalMock`` in the docs-test job, so the "after" side of every mapping
+is guaranteed to work.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from clappform.testing import LocalMock
+
+
+def build_mock() -> LocalMock:
+    import json
+
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+    from clappform.gen.clappform.data.v1.aggregate import aggregate_pb2
+    from clappform.testing import _local_mock
+
+    mock = LocalMock()
+    mock.seed_collection_slug("sales_orders", id="sales_orders-id")
+    mock.seed(
+        "sales_orders-id",
+        [
+            {"order_id": "A-1", "amount": 120.0, "status": "open"},
+            {"order_id": "A-2", "amount": 90.0, "status": "open"},
+        ],
+    )
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="run-1"),
+    )
+
+    # The guide's aggregate() example uses a $group, which the seeded double
+    # doesn't compute — stub the server's grouped answer and delegate every
+    # other read to the built-in handler.
+    def _aggregate(request):
+        stages = json.loads(request.pipeline) if request.pipeline else []
+        if any("$group" in s for s in stages):
+            grouped = [{"_id": "open", "total": 210.0}]
+            return [aggregate_pb2.AggregateResponse(data=json.dumps(grouped).encode())]
+        return _local_mock._handle_aggregate_stream(
+            mock, "unary_stream", request, aggregate_pb2.AggregateResponse
+        )
+
+    mock.on(
+        "/clappform.data.v1.aggregate.AggregateManagement/AggregateStream", _aggregate
+    )
+    return mock
+
+
+def run(transport: LocalMock) -> None:
+    # Old: clappform.Data(token, location) + clappform.Client(token, location)
+    # New: one client for every API. The cluster is discovered from DNS, so you
+    # no longer spell out a `target` host:port.
+    # --8<-- [start:connect]
+    from clappform import Clappform
+
+    cf = Clappform(location="preprod", api_key="cf_live_...")
+    # data-plane calls live on cf.data, client-API calls on cf.client —
+    # one binding, no separate Data / Client objects.
+    # --8<-- [end:connect]
+
+    cf = Clappform(
+        location="preprod", cluster="prod", api_key="cf_live_...", transport=transport
+    )
+
+    with cf:
+        # --8<-- [start:read]
+        # Old: build AggregateStreamRequest, json.dumps the pipeline, then
+        #      pd.concat([pd.DataFrame(json.loads(x.data)) for x in d.aggregate(req)])
+        # New: pass the pipeline straight to read(); you get a DataFrame back,
+        # already decoded and concatenated. read() with no pipeline reads the
+        # whole collection.
+        df = cf.data.collection("sales_orders").read(
+            pipeline=[{"$match": {"status": "open"}}]
+        )
+        # --8<-- [end:read]
+        assert len(df) == 2
+
+        # --8<-- [start:aggregate]
+        # A full pipeline (the old default) still works — pass it to aggregate().
+        # No json.dumps, no encode(), no manual concat of the streamed chunks.
+        revenue = cf.data.collection("sales_orders").aggregate(
+            [{"$group": {"_id": "$status", "total": {"$sum": "$amount"}}}]
+        )
+        # --8<-- [end:aggregate]
+        assert "total" in revenue.columns
+
+        # --8<-- [start:insert]
+        # Old: clappform.utils.insert_many_dataframe(collection, df, size=...)
+        #      then list(client.insert_many(request))
+        # New: append() chunks and streams for you, and returns rows written.
+        new_rows = pd.DataFrame([{"order_id": "A-3", "amount": 55.0, "status": "open"}])
+        written = cf.data.collection("sales_orders").append(new_rows)
+        # --8<-- [end:insert]
+        assert written == 1
+
+        # --8<-- [start:update]
+        # Old: batch the frame yourself, to_json each batch, wrap in
+        #      UpdateRequestByOid(data=...encode()), call update_replace_many.
+        # New: read keeps _id, so mutate and hand the frame back.
+        df["amount"] = df["amount"] * 1.1
+        cf.data.collection("sales_orders").update(df)
+        # --8<-- [end:update]
+
+        # --8<-- [start:delete]
+        orders = cf.data.collection("sales_orders")
+
+        # by explicit _id(s) — the direct replacement for delete_many_by_oids
+        orders.delete(oids=["order-id-1", "order-id-2"])
+
+        # ...or by filter, evaluated server-side (nothing round-trips)
+        orders.delete(where={"status": "cancelled"})
+        # --8<-- [end:delete]
+
+        # --8<-- [start:actionflow]
+        # Old: clappform.Client(...).actionflow_start(
+        #          actionflow_pb2.StartActionflow(actionflowid=ID, user=4, ...))
+        # New: on the same client, by id.
+        started = cf.client.actionflow.start(id="recalculate-dashboards")
+        # --8<-- [end:actionflow]
+        assert started is not None
+
+
+if __name__ == "__main__":
+    run(build_mock())

--- a/docs/snippets/quickstart.py
+++ b/docs/snippets/quickstart.py
@@ -18,7 +18,11 @@ def build_mock() -> LocalMock:
 
     ``cf.data.collection("sales_orders")`` resolves the slug to a UUID first, so
     the mock registers the slug->id mapping and seeds the store under that id.
+    The actionflow ``start`` RPC is not a data-plane call, so it gets an
+    explicit ``.on()`` stub keyed on its full gRPC method path.
     """
+    from clappform.gen.clappform.client.v1.actionflow import actionflow_pb2
+
     mock = LocalMock()
     mock.seed_collection_slug("sales_orders", id="sales_orders-id")
     mock.seed(
@@ -28,6 +32,10 @@ def build_mock() -> LocalMock:
             {"order_id": "A-2", "amount": 90.0, "status": "open", "region": "US"},
             {"order_id": "A-3", "amount": 40.0, "status": "closed", "region": "EU"},
         ],
+    )
+    mock.on(
+        "/clappform.client.v1.actionflow.ActionflowManagement/Start",
+        actionflow_pb2.StartActionflowResponse(message="started", uuid="run-abc123"),
     )
     return mock
 
@@ -48,6 +56,22 @@ def run(transport: LocalMock) -> None:
     cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...")
     # --8<-- [end:connect]
 
+    # The env var is illustrative; set a placeholder so the block below runs in
+    # CI without depending on the real environment. Not shown in the docs.
+    import os
+
+    os.environ.setdefault("CLAPPFORM_API_KEY", "cf_live_...")
+
+    # --8<-- [start:connect-env]
+    # Read the key from wherever your script keeps secrets — the library never
+    # touches the environment itself, so this stays your choice.
+    import os
+
+    from clappform import Clappform
+
+    cf = Clappform(location="acme", api_key=os.environ["CLAPPFORM_API_KEY"])
+    # --8<-- [end:connect-env]
+
     # The docs example connects for real; the test swaps in a stubbed transport
     # so the round-trip below runs with no network.
     cf = Clappform(location="acme", cluster="prod", api_key="cf_live_...", transport=transport)
@@ -56,8 +80,14 @@ def run(transport: LocalMock) -> None:
         # --8<-- [start:roundtrip]
         orders = cf.data.collection("sales_orders")
 
-        # read a filtered slice straight into a pandas DataFrame
-        df = orders.read(where={"status": "open"}, fields=["order_id", "amount", "region"])
+        # read a filtered slice straight into a pandas DataFrame — pass an
+        # aggregation pipeline; $match filters, $project picks columns
+        df = orders.read(
+            pipeline=[
+                {"$match": {"status": "open"}},
+                {"$project": {"order_id": 1, "amount": 1, "region": 1}},
+            ]
+        )
 
         # mutate with plain pandas
         df["amount_eur"] = df["amount"] * 1.08
@@ -68,6 +98,27 @@ def run(transport: LocalMock) -> None:
 
         assert len(df) == 2
         assert "amount_eur" in df.columns
+
+        # --8<-- [start:full-task]
+        # A complete task has the same shape almost every time: connect, read a
+        # slice, transform it with plain pandas, write it back, and (optionally)
+        # kick off a downstream flow. This is the whole loop end to end.
+        orders = cf.data.collection("sales_orders")
+
+        df = orders.read(pipeline=[{"$match": {"status": "open"}}])
+        print(f"pulled {len(df)} open orders")   # pulled 2 open orders
+
+        df["amount_eur"] = df["amount"] * 1.08
+        df["priority"] = df["amount_eur"] > 100
+
+        orders.update(df)                          # matched on _id, no args needed
+
+        # trigger a downstream actionflow; the response carries the run's uuid
+        started = cf.client.actionflow.start(id="recalculate-dashboards")
+        print(f"started run {started.uuid}")       # started run run-abc123
+        # --8<-- [end:full-task]
+        assert started.uuid == "run-abc123"
+        assert "priority" in df.columns
 
 
 if __name__ == "__main__":

--- a/docs/snippets/testing.py
+++ b/docs/snippets/testing.py
@@ -28,12 +28,12 @@ def run() -> None:
         # --8<-- [start:roundtrip]
         customers = cf.data.collection("customers")
 
-        pro = customers.read(where={"plan": "pro"})
+        pro = customers.read(pipeline=[{"$match": {"plan": "pro"}}])
         assert list(pro["email"]) == ["a@example.com"]
 
         # writes mutate the store, so a follow-up read sees them
         customers.replace_where({"plan": "free"}, {"plan": "pro"})
-        assert len(customers.read(where={"plan": "pro"})) == 2
+        assert len(customers.read(pipeline=[{"$match": {"plan": "pro"}}])) == 2
         # --8<-- [end:roundtrip]
 
         # --8<-- [start:assert-calls]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,9 @@ plugins:
 
 markdown_extensions:
   - admonition
+  # Collapsible admonitions (`??? note`) — used to fold the old-API reference
+  # blocks in the migration guide under the v6 code they replace.
+  - pymdownx.details
   - attr_list
   - toc:
       permalink: true
@@ -86,7 +89,10 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - How-to guides:
+      - Migrating from 4.x / 5.x: guides/migrating.md
+      - Cookbook: guides/cookbook.md
       - DataFrame flows: guides/dataframes.md
+      - Running inside an actionflow: guides/actionflow-scripts.md
       - Actionflows & listings: guides/actionflows-and-listings.md
       - Multi-cluster & multi-tenant: guides/multi-cluster.md
       - Error handling & retries: guides/errors-and-retries.md

--- a/src/clappform/dataframes.py
+++ b/src/clappform/dataframes.py
@@ -3,7 +3,8 @@
 This is the ergonomic layer people actually reach for:
 
     col = cf.data.collection("sales_orders")   # slug or UUID (resolved in _resolve)
-    df = col.read(where={"status": "open"}, fields=["id", "amount"], limit=1000)
+    df = col.read()                             # whole collection
+    df = col.read(pipeline=[{"$match": {"status": "open"}}])   # filtered slice
     col.append(df); col.update(df); col.upsert(df, on="order_id")
 
 A handle holds only ``(client, reference)`` — no connection, no state — and
@@ -256,30 +257,6 @@ class _AggregateReader:
         yield from stream
 
 
-def _compile_pipeline(
-    where: Mapping[str, Any] | None,
-    fields: Sequence[str] | None,
-    limit: int | None,
-) -> list[dict[str, Any]]:
-    """Compile ``where``/``fields``/``limit`` sugar into a Mongo pipeline.
-
-    These kwargs are purely client-side — the API never sees them. Each maps
-    to one stage in a plain aggregation pipeline (``$match`` / ``$project`` /
-    ``$limit``), producing exactly what an equivalent ``aggregate()`` call
-    would send. Order matches Mongo semantics: filter, then project, then cap.
-    """
-    pipeline: list[dict[str, Any]] = []
-    if where:
-        pipeline.append({"$match": dict(where)})
-    if fields:
-        pipeline.append({"$project": {field: 1 for field in fields}})
-    if limit is not None:
-        if limit < 0:
-            raise ValueError(f"limit must be non-negative, got {limit}")
-        pipeline.append({"$limit": limit})
-    return pipeline
-
-
 class CollectionHandle(_AggregateReader):
     """A handle to one collection: reads, writes, and ad-hoc aggregation.
 
@@ -312,27 +289,19 @@ class CollectionHandle(_AggregateReader):
     def fetch(
         self,
         *,
-        where: Mapping[str, Any] | None = None,
-        fields: Sequence[str] | None = None,
-        limit: int | None = None,
         pipeline: Sequence[Mapping[str, Any]] | None = None,
         batch_size: int | None = None,
         timeout: float | None = None,
     ) -> ReadResult:
         """Stream the collection into a :class:`ReadResult`.
 
-        ``where``/``fields``/``limit`` are client-side sugar compiled into a
-        ``$match``/``$project``/``$limit`` pipeline. ``pipeline=`` supplies a
-        full aggregation pipeline instead and is mutually exclusive with the
-        sugar — passing both is a caller error.
+        ``pipeline=`` is an aggregation pipeline applied server-side; omit it to
+        stream the whole collection. The pipeline is sent untouched, so it must
+        be in the syntax the collection's backend expects (Mongo stages for a
+        Mongo-backed collection, Elastic DSL for an Elastic-backed one).
+        :meth:`read` / :meth:`aggregate` are the DataFrame-returning twins.
         """
-        if pipeline is not None and (where or fields or limit is not None):
-            raise ValueError("pass either pipeline= or the where/fields/limit sugar, not both")
-        stages = (
-            [dict(stage) for stage in pipeline]
-            if pipeline is not None
-            else _compile_pipeline(where, fields, limit)
-        )
+        stages = [dict(stage) for stage in pipeline] if pipeline is not None else []
         encoded = _codec.encode_pipeline(stages)
         chunks = self._read_with_retry(encoded, batch_size, timeout)
         return ReadResult(chunks)
@@ -340,21 +309,19 @@ class CollectionHandle(_AggregateReader):
     def read(
         self,
         *,
-        where: Mapping[str, Any] | None = None,
-        fields: Sequence[str] | None = None,
-        limit: int | None = None,
+        pipeline: Sequence[Mapping[str, Any]] | None = None,
         batch_size: int | None = None,
         timeout: float | None = None,
     ) -> pd.DataFrame:
-        """The whole collection (or a filtered slice) as a pandas DataFrame.
+        """The whole collection (or a ``pipeline``-filtered slice) as a DataFrame.
 
-        Exactly ``fetch(...).to_pandas()``. ``_id`` is kept as a column so the
-        frame can be mutated and passed straight to :meth:`update`.
+        Exactly ``fetch(...).to_pandas()``. Omit ``pipeline`` for the whole
+        collection, or pass one to filter/project/reshape server-side. ``_id``
+        is kept as a column so the frame can be mutated and passed straight to
+        :meth:`update`.
         """
         return self.fetch(
-            where=where,
-            fields=fields,
-            limit=limit,
+            pipeline=pipeline,
             batch_size=batch_size,
             timeout=timeout,
         ).to_pandas()
@@ -362,21 +329,18 @@ class CollectionHandle(_AggregateReader):
     def iter_batches(
         self,
         *,
-        where: Mapping[str, Any] | None = None,
-        fields: Sequence[str] | None = None,
-        limit: int | None = None,
+        pipeline: Sequence[Mapping[str, Any]] | None = None,
         batch_size: int | None = None,
         timeout: float | None = None,
     ) -> Iterator[list[Record]]:
         """Stream records in memory-bounded batches (one list per gRPC chunk).
 
         ``batch_size`` asks the server to cap each chunk's row count; the
-        client yields whatever chunking the server sends back.
+        client yields whatever chunking the server sends back. ``pipeline=``
+        filters/reshapes server-side, exactly as on :meth:`read`.
         """
         return self.fetch(
-            where=where,
-            fields=fields,
-            limit=limit,
+            pipeline=pipeline,
             batch_size=batch_size,
             timeout=timeout,
         ).iter_batches()
@@ -390,9 +354,10 @@ class CollectionHandle(_AggregateReader):
     ) -> pd.DataFrame:
         """Run a caller-supplied aggregation pipeline, returning a DataFrame.
 
-        The pipeline is passed through untouched — use this for Elastic-backed
-        collections (whose DSL the ``where``/``fields`` sugar does not emit) or
-        any stage the sugar does not cover (``$group``, ``$sort``, ...).
+        The DataFrame-returning form of ``fetch(pipeline=...)``. The pipeline is
+        passed through untouched, so use the syntax the collection's backend
+        expects — Mongo stages (``$match``, ``$project``, ``$group``, ``$sort``,
+        ...) for a Mongo-backed collection, Elastic DSL for an Elastic-backed one.
         """
         return self.fetch(pipeline=pipeline, batch_size=batch_size, timeout=timeout).to_pandas()
 

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -50,21 +50,23 @@ def test_read_returns_whole_collection_as_frame(cf) -> None:
 def test_read_where_filters_rows(cf) -> None:
     client, mock = cf
     _seed_orders(mock)
-    df = client.data.collection(CID).read(where={"status": "open"})
+    df = client.data.collection(CID).read(pipeline=[{"$match": {"status": "open"}}])
     assert sorted(df["order_id"]) == [1, 3]
 
 
 def test_read_fields_projects_columns_but_keeps_id(cf) -> None:
     client, mock = cf
     _seed_orders(mock)
-    df = client.data.collection(CID).read(fields=["order_id", "amount"])
+    df = client.data.collection(CID).read(
+        pipeline=[{"$project": {"order_id": 1, "amount": 1}}]
+    )
     assert set(df.columns) == {"order_id", "amount", "_id"}
 
 
 def test_read_limit_caps_rows(cf) -> None:
     client, mock = cf
     _seed_orders(mock)
-    df = client.data.collection(CID).read(limit=2)
+    df = client.data.collection(CID).read(pipeline=[{"$limit": 2}])
     assert len(df) == 2
 
 
@@ -72,8 +74,8 @@ def test_read_equals_fetch_to_pandas(cf) -> None:
     client, mock = cf
     _seed_orders(mock)
     col = client.data.collection(CID)
-    from_read = col.read(where={"status": "open"})
-    from_fetch = col.fetch(where={"status": "open"}).to_pandas()
+    from_read = col.read(pipeline=[{"$match": {"status": "open"}}])
+    from_fetch = col.fetch(pipeline=[{"$match": {"status": "open"}}]).to_pandas()
     pd.testing.assert_frame_equal(from_read, from_fetch)
 
 
@@ -108,16 +110,16 @@ def test_empty_collection_reads_empty_frame(cf) -> None:
     assert df.empty
 
 
-def test_fetch_rejects_pipeline_with_sugar(cf) -> None:
+@pytest.mark.parametrize("kwarg", ["where", "fields", "limit"])
+def test_removed_read_sugar_is_rejected(cf, kwarg) -> None:
+    """The where/fields/limit read sugar was removed — passing it must error
+    rather than silently no-op, guarding against accidental reintroduction."""
     client, _mock = cf
-    with pytest.raises(ValueError, match="not both"):
-        client.data.collection(CID).fetch(pipeline=[{"$match": {}}], where={"x": 1})
-
-
-def test_negative_limit_rejected(cf) -> None:
-    client, _mock = cf
-    with pytest.raises(ValueError, match="non-negative"):
-        client.data.collection(CID).read(limit=-1)
+    col = client.data.collection(CID)
+    with pytest.raises(TypeError):
+        col.read(**{kwarg: {"status": "open"} if kwarg != "limit" else 1})
+    with pytest.raises(TypeError):
+        col.fetch(**{kwarg: {"status": "open"} if kwarg != "limit" else 1})
 
 
 def test_aggregate_passes_pipeline_through(cf) -> None:
@@ -267,27 +269,48 @@ def test_to_pandas_without_pandas_raises_install_hint(cf, monkeypatch) -> None:
         result.to_pandas()
 
 
-# -- pipeline compilation -------------------------------------------------
+# -- pipeline encoding ----------------------------------------------------
 
 
-def test_compiled_pipeline_matches_manual_aggregate(cf) -> None:
-    """read(where/fields/limit) must send the same pipeline aggregate() would."""
+def test_pipeline_is_sent_verbatim(cf) -> None:
+    """read(pipeline=...) sends the caller's stages untouched — the client
+    neither interprets nor rewrites them."""
     client, mock = cf
     _seed_orders(mock)
     col = client.data.collection(CID)
 
-    col.read(where={"status": "open"}, fields=["order_id"], limit=1)
-    sugar_pipeline = _last_pipeline(mock)
+    stages = [
+        {"$match": {"status": "open"}},
+        {"$project": {"order_id": 1}},
+        {"$limit": 1},
+    ]
+    col.read(pipeline=stages)
+    assert _last_pipeline(mock) == stages
 
-    col.aggregate(
-        [
-            {"$match": {"status": "open"}},
-            {"$project": {"order_id": 1}},
-            {"$limit": 1},
-        ]
-    )
-    manual_pipeline = _last_pipeline(mock)
-    assert sugar_pipeline == manual_pipeline
+
+def test_read_fetch_aggregate_encode_the_same_pipeline(cf) -> None:
+    """read(pipeline=p), fetch(pipeline=p) and aggregate(p) put the identical
+    pipeline on the wire — they differ only in return type."""
+    client, mock = cf
+    _seed_orders(mock)
+    col = client.data.collection(CID)
+    stages = [{"$match": {"status": "open"}}]
+
+    col.read(pipeline=stages)
+    from_read = _last_pipeline(mock)
+    col.fetch(pipeline=stages).to_pandas()
+    from_fetch = _last_pipeline(mock)
+    col.aggregate(stages)
+    from_aggregate = _last_pipeline(mock)
+    assert from_read == from_fetch == from_aggregate == stages
+
+
+def test_read_without_pipeline_sends_empty(cf) -> None:
+    """A bare read() streams the whole collection — an empty pipeline."""
+    client, mock = cf
+    _seed_orders(mock)
+    client.data.collection(CID).read()
+    assert _last_pipeline(mock) == []
 
 
 def _last_pipeline(mock: LocalMock):

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -39,6 +39,9 @@ def test_snippets_directory_is_present() -> None:
         "multi_cluster",
         "errors_and_retries",
         "testing",
+        "migrating",
+        "cookbook",
+        "actionflow_scripts",
     } <= found
 
 
@@ -80,8 +83,41 @@ def test_testing_snippet_runs() -> None:
     module.run()
 
 
+def test_migrating_snippet_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The connect block constructs location-only (DNS discovery); stub it, same
+    # as the quickstart, so the reader-facing snippet stays clean.
+    from clappform import _discovery
+
+    monkeypatch.setattr(_discovery, "discover_cluster", lambda location: "prod")
+    module = _load("migrating")
+    module.run(module.build_mock())
+
+
+def test_cookbook_snippet_runs() -> None:
+    module = _load("cookbook")
+    module.run(module.build_mock(), module.build_second_cluster_mock())
+
+
+def test_actionflow_scripts_snippet_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The connect-in-worker block constructs location-only (DNS discovery).
+    from clappform import _discovery
+
+    monkeypatch.setattr(_discovery, "discover_cluster", lambda location: "prod")
+    module = _load("actionflow_scripts")
+    module.run(module.build_mock())
+
+
 @pytest.mark.parametrize(
-    "name", ["quickstart", "dataframes", "client_operations", "multi_cluster"]
+    "name",
+    [
+        "quickstart",
+        "dataframes",
+        "client_operations",
+        "multi_cluster",
+        "migrating",
+        "cookbook",
+        "actionflow_scripts",
+    ],
 )
 def test_snippet_modules_import_clean(name: str) -> None:
     """Importing a snippet module must have no side effects (no top-level run)."""


### PR DESCRIPTION
## What

Two related changes, grounded in how the package is actually used (mined from the old `examples/actionflow_scripts`):

### 1. Reads take an aggregation pipeline — drop the `where`/`fields`/`limit` sugar (breaking)

The read sugar compiled a client-side `$match`/`$project`/`$limit` pipeline. It's removed in favour of one read idiom: pass an aggregation `pipeline` (or none for the whole collection), sent to the server **verbatim**. `aggregate(p)` stays as the DataFrame-returning twin of `read(pipeline=p)`.

Rationale: the client no longer interprets a query language of its own, so there's nothing to hand-maintain or re-verify when the backend query surface changes.

- `read` / `fetch` / `iter_batches` are now pipeline-only; `_compile_pipeline` deleted.
- Server-side `replace_where` / `delete(where=)` are **unchanged** — those are real query RPCs, not the sugar.
- Tests assert the removed kwargs now raise `TypeError`, and that pipelines are sent verbatim.

**Breaking change** (pre-1.0 alpha; no released version shipped the sugar):
```python
# before
col.read(where={"status": "open"}, fields=["a", "b"], limit=100)
# after
col.read(pipeline=[{"$match": {"status": "open"}}, {"$project": {"a": 1, "b": 1}}, {"$limit": 100}])
```

### 2. Expanded docs

- **Richer quickstart** — env-var key handling + a complete read → transform → write-back → start-a-flow task.
- **New: Migrating from 4.x / 5.x** — new-first mappings for every old operation; old form in collapsible reference blocks.
- **New: Cookbook** — copy-paste recipes for collection CRUD, single-record reads, file ingest, aggregation, actionflow starts, index management, app transfer, cross-cluster copy.
- **New: Running inside an actionflow** — client construction from worker-supplied values and passing start parameters.
- Cross-links + empty-result caution in existing guides; `pymdownx.details` enabled for the collapsibles.

Every code block is a runnable snippet exercised against `LocalMock` in CI, so the guides can't drift from the client.

## Verification

- `pytest`: **272 passed, 3 skipped**
- Docs snippets: **17 passed**
- `ruff`: clean
- `mkdocs build --strict`: exit 0

## Notes for review

- The front-page example is now `read(pipeline=[{"$match": ...}])` — more verbose than the old `read(where=...)`, which is the honest cost of a single read idiom. Happy to lead the landing page with a bare `read()` instead if preferred.
- The docs describe **only shipped API** — the earlier-proposed conveniences (`clappform.io`, `from_activity`, `cf.notifier.email`, typed summaries) are intentionally not documented yet.
